### PR TITLE
Call update-contextkit-providers after installation	

### DIFF
--- a/rpm/sensorfw.spec
+++ b/rpm/sensorfw.spec
@@ -145,6 +145,7 @@ fi
 
 %post
 /sbin/ldconfig
+update-contextkit-providers
 systemctl daemon-reload
 systemctl reload-or-try-restart sensord.service
 


### PR DESCRIPTION
This must be called after changes to /usr/share/contextkit/providers/. Not calling it can cause the contextkit provider to not work, and break the contextkit API for sensors.
