### PR TITLE
[sensorfw] Don't build anything but the client library for Qt 5.

### DIFF
--- a/rpm/sensorfw-qt5.yaml
+++ b/rpm/sensorfw-qt5.yaml
@@ -10,12 +10,10 @@ Description: |
 Sources:
     - "%{name}-%{version}.tar.bz2"
     - "sensorfw-rpmlintrc"
-    - "sensord.service"
-    - "sensord-daemon-conf-setup"
 Requires:
     - qt5-qtcore
     - GConf-dbus
-    - "%{name}-configs"
+    - sensorfw
 
 PkgConfigBR:
     - Qt5Core
@@ -24,19 +22,11 @@ PkgConfigBR:
     - Qt5Test
     - gconf-2.0
 
-#PkgBR:
-#    - doxygen
-#    - graphviz
-Obsoletes:
-    - sensorframework
-
-Provides: sensord-qt5
-
 Configure: none
 Builder: qmake5
-UseAsNeeded: no
-
-#QMakeOptions:
+Files:
+    - "%{_libdir}/libsensorclient-qt5.so.*"
+    - "%{_libdir}/libsensordatatypes-qt5.so.*"
 
 SubPackages:
     - Name: devel
@@ -48,38 +38,9 @@ SubPackages:
       Summary: Sensor framework daemon libraries development headers
       Description: |
         Development headers for sensor framework daemon and libraries.
-
-    - Name: tests
-      Group: Development/Libraries
-      Requires:
-          - qt5-qttest-devel
-          - testrunner-lite
-          - python
-      Summary: Unit test cases for sensord
-      Description: |
-        Contains unit test cases for CI environment.
-
-#    - Name: doc
-#      Group: Documentation
-#      Summary: API documentation for libsensord
-#      Description: |
-#        Doxygen-generated API documentation for sensord.
-
-    - Name: configs
-      Group: System/Libraries
-      Summary: Sensorfw configuration files
-      Description: |
-        Sensorfw configuration files.
-      BuildArch: noarch
-      AutoDepend: no
-      Requires:
-          - "%{name} = %{version}"
-      Provides:
-          - sensord-config
-          - config-n900
-          - config-aava
-          - config-icdk
-          - config-ncdk
-          - config-oemtablet
-          - config-oaktraili
-          - config-u8500
+      Files:
+          - "%{_libdir}/libsensordatatypes-qt5.so"
+          - "%{_libdir}/libsensorclient*.so"
+          - "%{_libdir}/pkgconfig/*"
+          - "%{_includedir}/sensord-qt5/*"
+          - "%{_datadir}/qt5/mkspecs/features/sensord.prf"

--- a/rpm/sensorfw.spec
+++ b/rpm/sensorfw.spec
@@ -33,7 +33,9 @@ BuildRequires:  pkgconfig(gconf-2.0)
 BuildRequires:  pkgconfig(QtDeclarative)
 BuildRequires:  pkgconfig(contextprovider-1.0)
 Provides:   sensord
+Provides:   sensorfw-qt4-compat
 Obsoletes:   sensorframework
+Obsoletes:   sensorfw-qt4-compat
 
 %description
 Sensor Framework provides an interface to hardware sensor drivers through logical sensors. This package contains sensor framework daemon and required libraries.
@@ -46,8 +48,7 @@ Requires:   %{name} = %{version}-%{release}
 Requires:   qt-devel
 
 %description devel
-Development headers for sensor framework daemon and libraries.
-
+%{summary}.
 
 %package tests
 Summary:    Unit test cases for sensord
@@ -87,16 +88,6 @@ Provides:   config-u8500
 
 %description configs
 Sensorfw configuration files.
-
-
-%package qt4-compat
-Summary:    Compatibiliy package for Qt 5 Sensorfw
-Group:      System/Libraries
-Requires(post): /sbin/ldconfig
-Requires(postun): /sbin/ldconfig
-
-%description qt4-compat
-Provides Qt 4 compatibility for Qt 5 Sensorfw files.
 
 
 %prep
@@ -149,13 +140,8 @@ update-contextkit-providers
 /sbin/ldconfig
 systemctl daemon-reload
 
-%post qt4-compat -p /sbin/ldconfig
-
-%postun qt4-compat -p /sbin/ldconfig
-
 %files
 %defattr(-,root,root,-)
-# >> files
 %attr(755,root,root)%{_sbindir}/sensord
 %{_libdir}/sensord/*.so
 %{_libdir}/*.so.*
@@ -166,48 +152,40 @@ systemctl daemon-reload
 /%{_lib}/systemd/system/sensord.service
 /%{_lib}/systemd/system/basic.target.wants/sensord.service
 %{_bindir}/sensord-daemon-conf-setup
+# >> files
 # << files
 
 %files devel
 %defattr(-,root,root,-)
-# >> files devel
 %{_libdir}/*.so
 %{_libdir}/pkgconfig/*
 %{_includedir}/sensord/*
 %{_datadir}/qt4/mkspecs/features/sensord.prf
-# From docs
-#%attr(644,root,root)%{_defaultdocdir}/sensord/html/*
+# >> files devel
 # << files devel
 
 %files tests
 %defattr(-,root,root,-)
-# >> files tests
 %{_libdir}/sensord/testing/*
 %attr(755,root,root)%{_datadir}/sensorfw-tests/*.p*
 %attr(644,root,root)%{_datadir}/sensorfw-tests/*.xml
 %attr(644,root,root)%{_datadir}/sensorfw-tests/*.conf
 %attr(755,root,root)%{_bindir}/*
+# >> files tests
 # << files tests
 
 %files contextfw-tests
 %defattr(-,root,root,-)
-# >> files contextfw-tests
 %attr(755,root,root)%{_datadir}/sensorfw-contextfw-tests/*.sh
 %attr(755,root,root)%{_datadir}/sensorfw-contextfw-tests/*.p*
 %attr(644,root,root)%{_datadir}/sensorfw-contextfw-tests/*.xml
+# >> files contextfw-tests
 # << files contextfw-tests
 
 %files configs
 %defattr(-,root,root,-)
-# >> files configs
 %config %{_sysconfdir}/%{name}/sensord.conf.d/*conf
 %config %{_sysconfdir}/%{name}/*conf
 %exclude %{_sysconfdir}/sensorfw/sensord.conf
+# >> files configs
 # << files configs
-
-%files qt4-compat
-%defattr(-,root,root,-)
-%{_libdir}/libsensorclient.so*
-%{_libdir}/libsensordatatypes.so*
-# >> files qt4-compat
-# << files qt4-compat

--- a/rpm/sensorfw.yaml
+++ b/rpm/sensorfw.yaml
@@ -29,7 +29,22 @@ PkgConfigBR:
 
 Obsoletes:
     - sensorframework
-Provides: sensord
+    - sensorfw-qt4-compat
+Provides:
+    - sensord
+    - sensorfw-qt4-compat
+Files:
+    - "%attr(755,root,root)%{_sbindir}/sensord"
+    - "%{_libdir}/sensord/*.so"
+    - "%{_libdir}/*.so.*"
+    - "%config %{_sysconfdir}/dbus-1/system.d/sensorfw.conf"
+    - "%config %{_sysconfdir}/sensorfw/sensord.conf"
+    - "%dir %{_sysconfdir}/%{name}/sensord.conf.d/"
+    - "%{_datadir}/contextkit/providers/com.nokia.SensorService.context"
+    - "/%{_lib}/systemd/system/sensord.service"
+    - "/%{_lib}/systemd/system/basic.target.wants/sensord.service"
+    - "%{_bindir}/sensord-daemon-conf-setup"
+
 
 Configure: none
 Builder: qmake
@@ -44,8 +59,12 @@ SubPackages:
       Requires:
           - qt-devel
       Summary: Sensor framework daemon libraries development headers
-      Description: |
-        Development headers for sensor framework daemon and libraries.
+      Description: "%{summary}."
+      Files:
+          - "%{_libdir}/*.so"
+          - "%{_libdir}/pkgconfig/*"
+          - "%{_includedir}/sensord/*"
+          - "%{_datadir}/qt4/mkspecs/features/sensord.prf"
 
     - Name: tests
       Group: Development/Libraries
@@ -54,7 +73,13 @@ SubPackages:
           - python
       Summary: Unit test cases for sensord
       Description: |
-        Contains unit test cases for CI environment.
+          Contains unit test cases for CI environment.
+      Files:
+          - "%{_libdir}/sensord/testing/*"
+          - "%attr(755,root,root)%{_datadir}/sensorfw-tests/*.p*"
+          - "%attr(644,root,root)%{_datadir}/sensorfw-tests/*.xml"
+          - "%attr(644,root,root)%{_datadir}/sensorfw-tests/*.conf"
+          - "%attr(755,root,root)%{_bindir}/*"
 
     - Name: contextfw-tests
       Group: Development/Libraries
@@ -63,7 +88,12 @@ SubPackages:
           - contextkit >= 0.3.6
       Summary: Test cases for sensord acting as context provider
       Description: |
-        Contains test cases for CI environment, for ensuring that sensord provides context properties correctly.
+          Contains test cases for CI environment, for ensuring that sensord provides context properties correctly.
+      Files:
+          - "%attr(755,root,root)%{_datadir}/sensorfw-contextfw-tests/*.sh"
+          - "%attr(755,root,root)%{_datadir}/sensorfw-contextfw-tests/*.p*"
+          - "%attr(644,root,root)%{_datadir}/sensorfw-contextfw-tests/*.xml"
+
 
 #    - Name: doc
 #      Group: Documentation
@@ -89,15 +119,8 @@ SubPackages:
           - config-oemtablet
           - config-oaktraili
           - config-u8500
-
-    - Name: qt4-compat
-      Group: System/Libraries
-      Summary: Compatibiliy package for Qt 5 Sensorfw 
-      Description: |
-        Provides Qt 4 compatibility for Qt 5 Sensorfw files.
-      AutoDepend: no
       Files:
-          - "%{_libdir}/libsensorclient.so*"
-          - "%{_libdir}/libsensordatatypes.so*"
-
+          - "%config %{_sysconfdir}/%{name}/sensord.conf.d/*conf"
+          - "%config %{_sysconfdir}/%{name}/*conf"
+          - "%exclude %{_sysconfdir}/sensorfw/sensord.conf"
 

--- a/sensorfw.pro
+++ b/sensorfw.pro
@@ -11,6 +11,17 @@ SUBDIRS = datatypes \
           tests \
           examples
 
+# Until the situation regarding contextkit etc is sorted out, we don't want to
+# port the daemon to Qt 5. So we build it only for Qt 4, and depend on it for
+# the Qt 5 package.
+#
+# When that is sorted out, we can reverse the situation, and only build the
+# daemon for Qt 5. There is no sense in having a co-installable daemon.
+equals(QT_MAJOR_VERSION, 5): {
+    SUBDIRS = datatypes qt-api
+}
+
+qt-api.depends = datatypes
 sensord.depends = datatypes adaptors sensors chains
 
 #include( doc/doc.pri )
@@ -35,18 +46,22 @@ PKGCONFIGFILES.path = /usr/lib/pkgconfig
 
 QTCONFIGFILES.files = sensord.prf
 
-DBUSCONFIGFILES.files = sensorfw.conf
-DBUSCONFIGFILES.path = /etc/dbus-1/system.d
+equals(QT_MAJOR_VERSION, 4):  {
+    DBUSCONFIGFILES.files = sensorfw.conf
+    DBUSCONFIGFILES.path = /etc/dbus-1/system.d
 
-SENSORDCONFIGFILE.files = config/sensor*.conf
-SENSORDCONFIGFILE.path = /etc/sensorfw
+    SENSORDCONFIGFILE.files = config/sensor*.conf
+    SENSORDCONFIGFILE.path = /etc/sensorfw
 
-SENSORDCONFIGFILES.files = config/90-sensord-default.conf
-SENSORDCONFIGFILES.path = /etc/sensorfw/sensord.conf.d
+    SENSORDCONFIGFILES.files = config/90-sensord-default.conf
+    SENSORDCONFIGFILES.path = /etc/sensorfw/sensord.conf.d
+
+    INSTALLS += DBUSCONFIGFILES SENSORDCONFIGFILE SENSORDCONFIGFILES
+}
 
 publicheaders.files += include/*.h
 
-INSTALLS += PKGCONFIGFILES QTCONFIGFILES DBUSCONFIGFILES SENSORDCONFIGFILE SENSORDCONFIGFILES
+INSTALLS += PKGCONFIGFILES QTCONFIGFILES
 
 equals(QT_MAJOR_VERSION, 4):  {
     OTHER_FILES += rpm/sensorfw.spec \


### PR DESCRIPTION
As Qt 5 is functionally crippled due to the state of contextkit meaning
virtually no plugins are operational / load, it makes no sense to try to port
the daemon to Qt 5 at this point.

Instead, leave the daemon Qt 4, and add a requirement on it from the Qt 5 client
library packaging. This also avoids problems with both packages providing the
same paths.

In the future, we can reverse this situation: have Qt 4 only build the client
library, and port the daemon to Qt 5 for good.

As a happy coincidence, this means that when you install both sensorfw and
sensorfw-qt5, you no longer end up having to flip a coin to determine which
daemon you get.
