### PR TITLE
[init] sensord should not be started in actdead

### DIFF
--- a/rpm/sensord.service
+++ b/rpm/sensord.service
@@ -2,6 +2,7 @@
 Description=Sensor daemon for sensor framework
 After=boardname.service
 Requires=dbus.socket
+Conflicts=actdead.target
 
 [Service]
 Type=forking 


### PR DESCRIPTION
In actdead mode we have minimal set of daemons running. There is no need for any sensors nor radios.
This should start only on USER state

Signed-off-by: Pekka Lundstrom pekka.lundstrom@jollamobile.com
