### PR TITLE
Previously when hybris-libsensorfw-qt5 is installed it brings sensorfw-q...

### DIFF
--- a/rpm/sensorfw-qt5-hybris.spec
+++ b/rpm/sensorfw-qt5-hybris.spec
@@ -45,7 +45,8 @@ Summary:    Sensorfw configuration files
 Group:      System/Libraries
 BuildArch:  noarch
 Requires:   %{name} = %{version}
-Provides:   config-hybris
+Provides:   sensord-configs
+Obsoletes:  sensorfw-qt5-configs <= 0.7.3.31
 
 %description configs
 Sensorfw configuration files.

--- a/rpm/sensorfw-qt5.spec
+++ b/rpm/sensorfw-qt5.spec
@@ -11,7 +11,7 @@ Source2:    sensord.service
 Source3:    sensord-daemon-conf-setup
 Requires:   qt5-qtcore
 Requires:   GConf-dbus
-Requires:   %{name}-configs
+Requires:   sensord-configs
 Requires:   systemd
 Requires(preun): systemd
 Requires(post): /sbin/ldconfig
@@ -61,7 +61,7 @@ Summary:    Sensorfw configuration files
 Group:      System/Libraries
 BuildArch:  noarch
 Requires:   %{name} = %{version}
-Provides:   sensord-config
+Provides:   sensord-configs
 Provides:   config-n900
 Provides:   config-aava
 Provides:   config-icdk

--- a/sensorfw.pro
+++ b/sensorfw.pro
@@ -62,7 +62,19 @@ equals(QT_MAJOR_VERSION, 5):  {
         DBUSCONFIGFILES.files = sensorfw.conf
         DBUSCONFIGFILES.path = /etc/dbus-1/system.d
 
-        SENSORDCONFIGFILE.files = config/sensor*.conf
+        SENSORDCONFIGFILE.files = config/sensord-rx_51.conf \
+		config/sensord-oaktrail.conf \
+		config/sensord-exopc.conf \
+		config/sensord-aava.conf \
+		config/sensord-rm_696.conf \
+		config/sensord-arm_grouper_0000.conf \
+		config/sensord-mrst_cdk.conf \
+		config/sensord-ncdk.conf \
+		config/sensord.conf \
+		config/sensord-rm_680.conf \
+		config/sensord-icdk.conf \
+		config/sensord-u8500.conf \
+
         SENSORDCONFIGFILE.path = /etc/sensorfw
 
         SENSORDCONFIGFILES.files = config/90-sensord-default.conf


### PR DESCRIPTION
...t5 and hybris-libsensorfw-qt5-configs

packaging in. The sensorfw-qt5 package then also takes in the sensorfw-qt5-configs which isn't really needed
with the hybris side. This patch makes the sensorfw-qt5-configs not to be installed when hybris-libsensorfw-qt5-configs
is there.

[packaging] Fix config packaging a bit to exclude not needed parts.

Signed-off-by: Marko Saukko marko.saukko@jollamobile.com
