### PR TITLE
[mer-hybris] Skip initial update if no proximity sensor is found

### DIFF
--- a/adaptors/hybrisproximityadaptor/hybrisproximityadaptor.cpp
+++ b/adaptors/hybrisproximityadaptor/hybrisproximityadaptor.cpp
@@ -72,6 +72,11 @@ void HybrisProximityAdaptor::sendInitialData()
             line = in.readLine();
         }
 
+        if (inputDev.isEmpty()) {
+            sensordLogW() << "No sysfs proximity device found";
+            return;
+        }
+
         struct input_absinfo absinfo;
         int fd;
         inputDev.replace("input","event");


### PR DESCRIPTION
On devices without proximity sensor, the `sendInitialData` function fails to determine a valid device name, and tries to open and ioctl `/dev/input/` (the directory). Avoid that, but issue a warning in case we expected the sysfs proximity device to be there.
