### PR TITLE
[sensorfw] Add real calibration level to hybris compass sensor.

### DIFF
--- a/adaptors/hybrisorientationadaptor/hybrisorientationadaptor.h
+++ b/adaptors/hybrisorientationadaptor/hybrisorientationadaptor.h
@@ -46,7 +46,7 @@ protected:
     void init();
 
 private:
-    DeviceAdaptorRingBuffer<TimedXyzData>* buffer;
+    DeviceAdaptorRingBuffer<CompassData>* buffer;
     int sensorType;
 
 };

--- a/chains/compasschain/compasschain.cpp
+++ b/chains/compasschain/compasschain.cpp
@@ -46,7 +46,7 @@ CompassChain::CompassChain(const QString& id) :
         hasOrientationAdaptor = true;
         setValid(orientAdaptor->isValid());
         if (orientAdaptor->isValid())
-            orientationdataReader = new BufferReader<TimedXyzData>(1);
+            orientationdataReader = new BufferReader<CompassData>(1);
 
         orientationFilter = sm.instantiateFilter("orientationfilter");
         Q_ASSERT(orientationFilter);

--- a/chains/compasschain/compasschain.h
+++ b/chains/compasschain/compasschain.h
@@ -74,7 +74,7 @@ private:
     BufferReader<CalibratedMagneticFieldData> *magReader;
 
     DeviceAdaptor *orientAdaptor;
-    BufferReader<TimedXyzData> *orientationdataReader;
+    BufferReader<CompassData> *orientationdataReader;
 
 
     FilterBase *compassFilter;

--- a/chains/compasschain/orientationfilter.cpp
+++ b/chains/compasschain/orientationfilter.cpp
@@ -24,17 +24,20 @@
 
 OrientationFilter::OrientationFilter()
     : orientDataSink(this, &OrientationFilter::orientDataAvailable),
-      level(3) //presume this is fully calibrated
+      level(0) //presume this is fully calibrated
 {
     addSink(&orientDataSink, "orientsink");
     addSource(&magSource, "magnorthangle");
 }
 
-void OrientationFilter::orientDataAvailable(unsigned, const TimedXyzData *data)
+void OrientationFilter::orientDataAvailable(unsigned, const CompassData *data)
 {
     CompassData compassData; //north angle
     compassData.timestamp_ = data->timestamp_;
-    compassData.degrees_ = data->x_ * .001;
-    compassData.level_ = level;
+    compassData.degrees_ = data->degrees_ * .001;
+    if (data->level_ > 0 && data->level_ < 3.1)
+        compassData.level_ = data->level_;
+    else
+        compassData.level_ = level;
     magSource.propagate(1, &compassData);
 }

--- a/chains/compasschain/orientationfilter.h
+++ b/chains/compasschain/orientationfilter.h
@@ -43,8 +43,8 @@ protected:
 private:
     Source<CompassData> magSource;
 
-    Sink<OrientationFilter, TimedXyzData> orientDataSink;
-    void orientDataAvailable(unsigned, const TimedXyzData*);
+    Sink<OrientationFilter, CompassData> orientDataSink;
+    void orientDataAvailable(unsigned, const CompassData*);
     qreal level;
     qreal oldHeading;
 };


### PR DESCRIPTION
This makes the orientationfilter into a compassfilter, but not changing
the name. hybris calls it orientation sensor, even though it's
a calibrated compass.

The Jolla compass never seems to get above SENSOR_STATUS_ACCURACY_LOW, even after calibrated, but at least we know when its not calibrated and user needs to do the figure 8 calibration gesture.
