### PR TITLE
set minDelay to 0 if larger than our max.

### DIFF
--- a/core/hybrisadaptor.cpp
+++ b/core/hybrisadaptor.cpp
@@ -363,6 +363,8 @@ void HybrisAdaptor::init()
     sensorHandle = hybrisManager()->handleForType(sensorType);
     maxRange = hybrisManager()->maxRange(sensorType);
     minDelay = hybrisManager()->minDelay(sensorType);
+    if (minDelay > 1000)
+        minDelay = 0;
     resolution = hybrisManager()->resolution(sensorType);
 }
 


### PR DESCRIPTION
Some sensors data may not be truely ready yet.
