### PR TITLE
Depends on dbus service rather than socket

### DIFF
--- a/rpm/sensord.service
+++ b/rpm/sensord.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Sensor daemon for sensor framework
 After=boardname.service
-Requires=dbus.socket
+Requires=dbus.service
 Conflicts=actdead.target
 
 [Service]


### PR DESCRIPTION
With newer dbus depending on dbus.socket doesn't work and block the boot.
