### PR TITLE
Change hybris proximity & als default values

### DIFF
--- a/adaptors/hybrisalsadaptor/hybrisalsadaptor.h
+++ b/adaptors/hybrisalsadaptor/hybrisalsadaptor.h
@@ -43,13 +43,15 @@ public:
     bool startSensor();
     void stopSensor();
 
+    void sendInitialData();
+
 protected:
     void processSample(const sensors_event_t& data);
     void init();
 
 private:
     DeviceAdaptorRingBuffer<TimedUnsigned>* buffer;
-
+    unsigned lastLightValue;
 
 };
 #endif

--- a/adaptors/hybrisproximityadaptor/hybrisproximityadaptor.h
+++ b/adaptors/hybrisproximityadaptor/hybrisproximityadaptor.h
@@ -52,5 +52,6 @@ protected:
 private:
     DeviceAdaptorRingBuffer<ProximityData>* buffer;
     int sensorType;
+    bool lastNearValue;
 };
 #endif


### PR DESCRIPTION
This would help integrations when sensors are not found.

Often screen blanking depends on proximity and/or als values. When these sensors are missing or not found on the system, the screen would be blank, causing confusion and possibly blocking integration work.