### PR TITLE
Resume regadless when at least one client has standbyOverride.

### DIFF
--- a/core/deviceadaptor.cpp
+++ b/core/deviceadaptor.cpp
@@ -76,16 +76,15 @@ RingBufferBase* AdaptedSensorEntry::buffer() const
     return buffer_;
 }
 
-// TODO: correct initialization of screenBlanked is disabled since it
-// most probably has effect for testcase functionalities.
+// TODO: correct initialization of screenBlanked most probably has effect for testcase functionalities.
 DeviceAdaptor::DeviceAdaptor(const QString& id) :
     NodeBase(id),
     standbyOverride_(false),
-//#ifdef SENSORFW_MCE_WATCHER
-//    screenBlanked_(!SensorManager::instance().MCEWatcher()->displayEnabled())
-//#else
+#ifdef SENSORFW_MCE_WATCHER
+    screenBlanked_(!SensorManager::instance().MCEWatcher()->displayEnabled())
+#else
     screenBlanked_(false)
-//#endif
+#endif
 {
     setValid(true);
 }
@@ -121,15 +120,10 @@ RingBufferBase* DeviceAdaptor::findBuffer(const QString& name) const
 bool DeviceAdaptor::setStandbyOverride(bool override)
 {
     standbyOverride_ = override;
-
-    if (screenBlanked_)
-    {
-        if(override)
-        {
+    if (screenBlanked_) {
+        if (override) {
             resume();
-        }
-        else
-        {
+        } else {
             standby();
         }
     }

--- a/core/hybrisadaptor.h
+++ b/core/hybrisadaptor.h
@@ -27,6 +27,7 @@
 
 #include "deviceadaptor.h"
 #include <hardware/sensors.h>
+#define SENSORFW_MCE_WATCHER
 
 class HybrisAdaptor;
 


### PR DESCRIPTION
Fixes issue when screen is blanked and at least one client
has standbyOverride set to true and another one starts
with standbyOverride set to false.