### PR TITLE
[sensorfw] add accel, als, gyro & mag evdev adaptors.

### DIFF
--- a/adaptors/accelerometeradaptor/accelerometeradaptor.cpp
+++ b/adaptors/accelerometeradaptor/accelerometeradaptor.cpp
@@ -43,7 +43,7 @@ AccelerometerAdaptor::AccelerometerAdaptor(const QString& id) :
 {
     accelerometerBuffer_ = new DeviceAdaptorRingBuffer<OrientationData>(1);
     setAdaptedSensor("accelerometer", "Internal accelerometer coordinates", accelerometerBuffer_);
-    setDescription("Input device accelerometer adaptor (lis302d)");
+    setDescription("Input device accelerometer adaptor");
 }
 
 AccelerometerAdaptor::~AccelerometerAdaptor()
@@ -56,19 +56,20 @@ void AccelerometerAdaptor::interpretEvent(int src, struct input_event *ev)
     Q_UNUSED(src);
 
     switch (ev->type) {
-        case EV_ABS:
-            switch (ev->code) {
-                case ABS_X:
-                    orientationValue_.x_ = ev->value;
-                    break;
-                case ABS_Y:
-                    orientationValue_.y_ = ev->value;
-                    break;
-                case ABS_Z:
-                    orientationValue_.z_ = ev->value;
-                    break;
-            }
+    case EV_REL:
+    case EV_ABS:
+        switch (ev->code) {
+        case ABS_X:
+            orientationValue_.x_ = ev->value;
             break;
+        case ABS_Y:
+            orientationValue_.y_ = ev->value;
+            break;
+        case ABS_Z:
+            orientationValue_.z_ = ev->value;
+            break;
+        }
+        break;
     }
 }
 
@@ -87,7 +88,7 @@ void AccelerometerAdaptor::commitOutput(struct input_event *ev)
     d->y_ = orientationValue_.y_;
     d->z_ = orientationValue_.z_;
 
-    sensordLogT() << "Accelerometer reading: " << d->x_ << ", " << d->y_ << ", " << d->z_;
+//    sensordLogT() << "Accelerometer reading: " << d->x_ << ", " << d->y_ << ", " << d->z_;
 
     accelerometerBuffer_->commit();
     accelerometerBuffer_->wakeUpReaders();
@@ -95,8 +96,7 @@ void AccelerometerAdaptor::commitOutput(struct input_event *ev)
 
 unsigned int AccelerometerAdaptor::evaluateIntervalRequests(int& sessionId) const
 {
-    if (m_intervalMap.size() == 0)
-    {
+    if (m_intervalMap.size() == 0) {
         sessionId = -1;
         return defaultInterval();
     }
@@ -106,8 +106,7 @@ unsigned int AccelerometerAdaptor::evaluateIntervalRequests(int& sessionId) cons
     unsigned int highestValue = it.value();
     int winningSessionId = it.key();
 
-    for (++it; it != m_intervalMap.constEnd(); ++it)
-    {
+    for (++it; it != m_intervalMap.constEnd(); ++it) {
         if (((it.value() < highestValue) && (it.value() > 0)) || highestValue == 0) {
             highestValue = it.value();
             winningSessionId = it.key();

--- a/adaptors/adaptors.pro
+++ b/adaptors/adaptors.pro
@@ -13,12 +13,14 @@ contains(CONFIG,hybris) {
     } else {
 
 SUBDIRS = alsadaptor \
+          alsadaptor-evdev \
           alsadaptor-sysfs \
           alsadaptor-ascii \
           tapadaptor \
           accelerometeradaptor \
           magnetometeradaptor \
           magnetometeradaptor-ascii \
+          magnetometeradaptor-evdev \
           magnetometeradaptor-ncdk \
           touchadaptor \
           kbslideradaptor \
@@ -26,7 +28,8 @@ SUBDIRS = alsadaptor \
           proximityadaptor-evdev \
           proximityadaptor-ascii \
           mrstaccelerometer \
-          gyroscopeadaptor
+          gyroscopeadaptor \
+          gyroscopeadaptor-evdev
 SUDBIRS += oemtabletmagnetometeradaptor
 SUBDIRS += pegatronaccelerometeradaptor 
 SUBDIRS += oemtabletalsadaptor-ascii

--- a/adaptors/alsadaptor-evdev/alsadaptor-evdev.pro
+++ b/adaptors/alsadaptor-evdev/alsadaptor-evdev.pro
@@ -1,0 +1,9 @@
+TARGET = alsadaptor-evdev
+
+HEADERS += alsevdevadaptor.h \
+           alsadaptor-evdevplugin.h
+
+SOURCES += alsevdevadaptor.cpp \
+           alsadaptor-evdevplugin.cpp
+
+include( ../adaptor-config.pri )

--- a/adaptors/alsadaptor-evdev/alsadaptor-evdevplugin.cpp
+++ b/adaptors/alsadaptor-evdev/alsadaptor-evdevplugin.cpp
@@ -1,0 +1,43 @@
+/**
+   @file alsadaptorplugin-sysfs.cpp
+   @brief Plugin for ALSAdaptorSysfs
+
+   <p>
+   Copyright (C) 2009-2010 Nokia Corporation
+   Copyright (C) 2015 Jolla
+
+   @author Lorn Potter <lorn.potter@jolla.com>
+   @author Timo Rongas <ext-timo.2.rongas@nokia.com>
+   @author Markus Lehtonen <markus.lehtonen@nokia.com>
+
+   This file is part of Sensord.
+
+   Sensord is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License
+   version 2.1 as published by the Free Software Foundation.
+
+   Sensord is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Sensord.  If not, see <http://www.gnu.org/licenses/>.
+   </p>
+*/
+
+#include "alsadaptor-evdevplugin.h"
+#include "alsevdevadaptor.h"
+#include "sensormanager.h"
+#include "logging.h"
+
+void ALSAdaptorEvdevPlugin::Register(class Loader&)
+{
+    sensordLogD() << "registering alsadaptor-evdev";
+    SensorManager& sm = SensorManager::instance();
+    sm.registerDeviceAdaptor<ALSAdaptorEvdev>("alsadaptor");
+}
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+Q_EXPORT_PLUGIN2(alsadaptor-evdev, ALSAdaptorEvdevPlugin)
+#endif

--- a/adaptors/alsadaptor-evdev/alsadaptor-evdevplugin.h
+++ b/adaptors/alsadaptor-evdev/alsadaptor-evdevplugin.h
@@ -1,0 +1,45 @@
+/**
+   @file alsadaptor-evdevplugin.h
+   @brief Plugin for ALSAdaptorEvdevPlugin
+
+   <p>
+   Copyright (C) 2009-2010 Nokia Corporation
+   Copyright (C) 2015 Jolla
+
+   @author Lorn Potter <lorn.potter@jolla.com>
+   @author Timo Rongas <ext-timo.2.rongas@nokia.com>
+   @author Markus Lehtonen <markus.lehtonen@nokia.com>
+
+   This file is part of Sensord.
+
+   Sensord is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License
+   version 2.1 as published by the Free Software Foundation.
+
+   Sensord is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Sensord.  If not, see <http://www.gnu.org/licenses/>.
+   </p>
+*/
+
+#ifndef ALSADAPTOR_EVDEVPLUGIN_H
+#define ALSADAPTOR_SYSFSPLUGIN_H
+
+#include "plugin.h"
+
+class ALSAdaptorEvdevPlugin : public Plugin
+{
+    Q_OBJECT
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+    Q_PLUGIN_METADATA(IID "com.nokia.SensorService.Plugin/1.0")
+#endif
+
+private:
+    void Register(class Loader& l);
+};
+
+#endif

--- a/adaptors/alsadaptor-evdev/alsevdevadaptor.cpp
+++ b/adaptors/alsadaptor-evdev/alsevdevadaptor.cpp
@@ -1,0 +1,151 @@
+/**
+   @file alsevdevadaptor.cpp
+   @brief Plugin for ALSAdaptorEvdev
+
+   <p>
+   Copyright (C) 2009-2010 Nokia Corporation
+   Copyright (C) 2015 Jolla
+
+   @author Lorn Potter <lorn.potter@jolla.com>
+   @author Timo Rongas <ext-timo.2.rongas@nokia.com>
+   @author Markus Lehtonen <markus.lehtonen@nokia.com>
+
+   This file is part of Sensord.
+
+   Sensord is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License
+   version 2.1 as published by the Free Software Foundation.
+
+   Sensord is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Sensord.  If not, see <http://www.gnu.org/licenses/>.
+   </p>
+*/
+
+#include "alsevdevadaptor.h"
+#include "config.h"
+#include "logging.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/input.h>
+#include <unistd.h>
+#include <QMap>
+
+#include "datatypes/utils.h"
+
+ALSAdaptorEvdev::ALSAdaptorEvdev(const QString& id) :
+    InputDevAdaptor(id, 1)
+{
+    alsBuffer_ = new DeviceAdaptorRingBuffer<TimedUnsigned>(1);
+    setAdaptedSensor("als", "Internal ambient light sensor lux values", alsBuffer_);
+    setDescription("Input device als adaptor");
+    powerStatePath_ = Config::configuration()->value("als/powerstate_path").toByteArray();
+    introduceAvailableDataRange(DataRange(0, 4095, 1));
+    setDefaultInterval(10);
+}
+
+ALSAdaptorEvdev::~ALSAdaptorEvdev()
+{
+}
+
+void ALSAdaptorEvdev::interpretEvent(int src, struct input_event *ev)
+{
+    Q_UNUSED(src);
+
+    switch (ev->type) {
+    case EV_ABS:
+        switch (ev->code) {
+        case ABS_X:
+        case ABS_MISC:
+            alsValue_ = ev->value;
+            break;
+        }
+        break;
+    }
+}
+
+void ALSAdaptorEvdev::interpretSync(int src, struct input_event *ev)
+{
+    Q_UNUSED(src);
+    commitOutput(ev);
+}
+
+void ALSAdaptorEvdev::commitOutput(struct input_event *ev)
+{
+    TimedUnsigned* lux = alsBuffer_->nextSlot();
+    lux->value_ = alsValue_;
+
+    lux->timestamp_ = Utils::getTimeStamp(&(ev->time));
+
+    alsBuffer_->commit();
+    alsBuffer_->wakeUpReaders();
+}
+
+unsigned int ALSAdaptorEvdev::evaluateIntervalRequests(int& sessionId) const
+{
+    unsigned int highestValue = 0;
+    int winningSessionId = -1;
+
+    if (m_intervalMap.size() == 0) {
+        sessionId = winningSessionId;
+        return defaultInterval();
+    }
+
+    // Get the smallest positive request, 0 is reserved for HW wakeup
+    QMap<int, unsigned int>::const_iterator it;
+    it = m_intervalMap.begin();
+    highestValue = it.value();
+    winningSessionId = it.key();
+
+    for (++it; it != m_intervalMap.constEnd(); ++it) {
+        if ((it.value() < highestValue) && (it.value() > 0)) {
+            highestValue = it.value();
+            winningSessionId = it.key();
+        }
+    }
+
+    sessionId = winningSessionId;
+    return highestValue > 0 ? highestValue : defaultInterval();
+}
+
+bool ALSAdaptorEvdev::startSensor()
+{
+    if (!powerStatePath_.isEmpty()) {
+        writeToFile(powerStatePath_, "1");
+    }
+    if (SysfsAdaptor::startSensor()) {
+        return true;
+    }
+    return false;
+}
+
+void ALSAdaptorEvdev::stopSensor()
+{
+    if (!powerStatePath_.isEmpty()) {
+        writeToFile(powerStatePath_, "0");
+    }
+
+    SysfsAdaptor::stopSensor();
+}
+
+bool ALSAdaptorEvdev::standby()
+{
+    if (SysfsAdaptor::standby()) {
+        stopSensor();
+        return true;
+    }
+    return false;
+}
+
+bool ALSAdaptorEvdev::resume()
+{
+    if (SysfsAdaptor::resume()) {
+        startSensor();
+        return true;
+    }
+    return false;
+}

--- a/adaptors/alsadaptor-evdev/alsevdevadaptor.h
+++ b/adaptors/alsadaptor-evdev/alsevdevadaptor.h
@@ -1,0 +1,79 @@
+/**
+   @file inputdevadaptor.cpp
+   @brief Contains ALSAdaptorEvdev.
+
+   <p>
+   Copyright (C) 2009-2010 Nokia Corporation
+   Copyright (C) 2015 Jolla
+
+   @author Lorn Potter <lorn.potter@jolla.com>
+   @author Timo Rongas <ext-timo.2.rongas@nokia.com>
+   @author Markus Lehtonen <markus.lehtonen@nokia.com>
+   Sensord is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License
+   version 2.1 as published by the Free Software Foundation.
+
+   Sensord is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Sensord.  If not, see <http://www.gnu.org/licenses/>.
+   </p>
+*/
+#ifndef ALSEVDEVADAPTOR_H
+#define ALSEVDEVADAPTOR_H
+
+#include "inputdevadaptor.h"
+#include "deviceadaptorringbuffer.h"
+#include "datatypes/orientationdata.h"
+#include <QTime>
+
+class ALSAdaptorEvdev : public InputDevAdaptor
+{
+    Q_OBJECT
+public:
+    /**
+     * Factory method for gaining a new instance of AccelerometerAdaptor class.
+     * @param id Identifier for the adaptor.
+     */
+    static DeviceAdaptor* factoryMethod(const QString& id)
+    {
+        return new ALSAdaptorEvdev(id);
+    }
+
+    virtual bool startSensor();
+
+    virtual void stopSensor();
+
+    virtual bool standby();
+
+    virtual bool resume();
+
+protected:
+    /**
+     * Constructor.
+     * @param id Identifier for the adaptor.
+     */
+    ALSAdaptorEvdev(const QString& id);
+    ~ALSAdaptorEvdev();
+
+    /**
+     * Reimplement to allow for 0 interval to be the slowest entry.
+     */
+    virtual unsigned int evaluateIntervalRequests(int& sessionId) const;
+
+private:
+    DeviceAdaptorRingBuffer<TimedUnsigned>* alsBuffer_;
+
+    unsigned alsValue_;
+
+    void interpretEvent(int src, struct input_event *ev);
+    void commitOutput(struct input_event *ev);
+    void interpretSync(int src, struct input_event *ev);
+    QByteArray powerStatePath_;
+
+};
+
+#endif

--- a/adaptors/gyroscopeadaptor-evdev/gyroadaptor-evdevplugin.cpp
+++ b/adaptors/gyroscopeadaptor-evdev/gyroadaptor-evdevplugin.cpp
@@ -1,0 +1,43 @@
+/**
+   @file gyroadaptor-evdevplugin.cpp
+   @brief Plugin for GyroAdaptorEvdevPlugin
+
+   <p>
+   Copyright (C) 2009-2010 Nokia Corporation
+   Copyright (C) 2015 Jolla
+
+   @author Lorn Potter <lorn.potter@jolla.com>
+   @author Timo Rongas <ext-timo.2.rongas@nokia.com>
+   @author Markus Lehtonen <markus.lehtonen@nokia.com>
+
+   This file is part of Sensord.
+
+   Sensord is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License
+   version 2.1 as published by the Free Software Foundation.
+
+   Sensord is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Sensord.  If not, see <http://www.gnu.org/licenses/>.
+   </p>
+*/
+
+#include "gyroadaptor-evdevplugin.h"
+#include "gyroevdevadaptor.h"
+#include "sensormanager.h"
+#include "logging.h"
+
+void GyroAdaptorEvdevPlugin::Register(class Loader&)
+{
+    sensordLogD() << "registering gyroadaptor-evdev";
+    SensorManager& sm = SensorManager::instance();
+    sm.registerDeviceAdaptor<GyroAdaptorEvdev>("gyroscopeadaptor");
+}
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+Q_EXPORT_PLUGIN2(gyroadaptor-evdev, GyroAdaptorEvdevPlugin)
+#endif

--- a/adaptors/gyroscopeadaptor-evdev/gyroadaptor-evdevplugin.h
+++ b/adaptors/gyroscopeadaptor-evdev/gyroadaptor-evdevplugin.h
@@ -1,0 +1,45 @@
+/**
+   @file alsadaptor-evdevplugin.h
+   @brief Plugin for ALSAdaptorEvdevPlugin
+
+   <p>
+   Copyright (C) 2009-2010 Nokia Corporation
+   Copyright (C) 2015 Jolla
+
+   @author Lorn Potter <lorn.potter@jolla.com>
+   @author Timo Rongas <ext-timo.2.rongas@nokia.com>
+   @author Markus Lehtonen <markus.lehtonen@nokia.com>
+
+   This file is part of Sensord.
+
+   Sensord is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License
+   version 2.1 as published by the Free Software Foundation.
+
+   Sensord is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Sensord.  If not, see <http://www.gnu.org/licenses/>.
+   </p>
+*/
+
+#ifndef GYROADAPTOR_EVDEVPLUGIN_H
+#define GYROADAPTOR_EVDEVPLUGIN_H
+
+#include "plugin.h"
+
+class GyroAdaptorEvdevPlugin : public Plugin
+{
+    Q_OBJECT
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+    Q_PLUGIN_METADATA(IID "com.nokia.SensorService.Plugin/1.0")
+#endif
+
+private:
+    void Register(class Loader& l);
+};
+
+#endif

--- a/adaptors/gyroscopeadaptor-evdev/gyroadaptor-evdevplugin.h.autosave
+++ b/adaptors/gyroscopeadaptor-evdev/gyroadaptor-evdevplugin.h.autosave
@@ -1,0 +1,45 @@
+/**
+   @file alsadaptor-evdevplugin.h
+   @brief Plugin for GyroAdaptorEvdevPlugin
+
+   <p>
+   Copyright (C) 2009-2010 Nokia Corporation
+   Copyright (C) 2015 Jolla
+
+   @author Lorn Potter <lorn.potter@jolla.com>
+   @author Timo Rongas <ext-timo.2.rongas@nokia.com>
+   @author Markus Lehtonen <markus.lehtonen@nokia.com>
+
+   This file is part of Sensord.
+
+   Sensord is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License
+   version 2.1 as published by the Free Software Foundation.
+
+   Sensord is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Sensord.  If not, see <http://www.gnu.org/licenses/>.
+   </p>
+*/
+
+#ifndef GYROADAPTOR_EVDEVPLUGIN_H
+#define GYROADAPTOR_EVDEVPLUGIN_H
+
+#include "plugin.h"
+
+class GyroAdaptorEvdevPlugin : public Plugin
+{
+    Q_OBJECT
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+    Q_PLUGIN_METADATA(IID "com.nokia.SensorService.Plugin/1.0")
+#endif
+
+private:
+    void Register(class Loader& l);
+};
+
+#endif

--- a/adaptors/gyroscopeadaptor-evdev/gyroevdevadaptor.cpp
+++ b/adaptors/gyroscopeadaptor-evdev/gyroevdevadaptor.cpp
@@ -1,0 +1,160 @@
+/**
+   @file gyroevdevadaptor.cpp
+   @brief Plugin for GyroAdaptorEvdev
+
+   <p>
+   Copyright (C) 2009-2010 Nokia Corporation
+   Copyright (C) 2015 Jolla
+
+   @author Lorn Potter <lorn.potter@jolla.com>
+   @author Timo Rongas <ext-timo.2.rongas@nokia.com>
+   @author Markus Lehtonen <markus.lehtonen@nokia.com>
+
+   This file is part of Sensord.
+
+   Sensord is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License
+   version 2.1 as published by the Free Software Foundation.
+
+   Sensord is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Sensord.  If not, see <http://www.gnu.org/licenses/>.
+   </p>
+*/
+
+#include "gyroevdevadaptor.h"
+#include "config.h"
+#include "logging.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/input.h>
+#include <unistd.h>
+#include <QMap>
+
+#include "datatypes/utils.h"
+
+GyroAdaptorEvdev::GyroAdaptorEvdev(const QString& id) :
+    InputDevAdaptor(id, 1)
+{
+    gyroscopeBuffer_ = new DeviceAdaptorRingBuffer<TimedXyzData>(1);
+    setAdaptedSensor("gyroscope", "Internal gyroscope values", gyroscopeBuffer_);
+    setDescription("Input device gyroscope adaptor");
+    powerStatePath_ = Config::configuration()->value("gyroscope/powerstate_path").toByteArray();
+   // introduceAvailableDataRange(DataRange(0, 4095, 1));
+    setDefaultInterval(10);
+}
+
+GyroAdaptorEvdev::~GyroAdaptorEvdev()
+{
+    delete gyroscopeBuffer_;
+}
+
+void GyroAdaptorEvdev::interpretEvent(int src, struct input_event *ev)
+{
+    Q_UNUSED(src);
+
+    switch (ev->type) {
+    case EV_ABS:
+    case EV_REL:
+        switch (ev->code) {
+        case ABS_X:
+            gyroValue_.x_ = ev->value;
+            break;
+        case ABS_Y:
+            gyroValue_.y_ = ev->value;
+            break;
+        case ABS_Z:
+            gyroValue_.z_ = ev->value;
+            break;
+        }
+        break;
+    }
+}
+
+void GyroAdaptorEvdev::interpretSync(int src, struct input_event *ev)
+{
+    Q_UNUSED(src);
+    commitOutput(ev);
+}
+
+void GyroAdaptorEvdev::commitOutput(struct input_event *ev)
+{
+    TimedXyzData* gyroData = gyroscopeBuffer_->nextSlot();
+    gyroData->x_ = gyroValue_.x_;
+    gyroData->y_ = gyroValue_.y_;
+    gyroData->z_ = gyroValue_.z_;
+
+    gyroData->timestamp_ = Utils::getTimeStamp(&(ev->time));
+
+    gyroscopeBuffer_->commit();
+    gyroscopeBuffer_->wakeUpReaders();
+}
+
+unsigned int GyroAdaptorEvdev::evaluateIntervalRequests(int& sessionId) const
+{
+    unsigned int highestValue = 0;
+    int winningSessionId = -1;
+
+    if (m_intervalMap.size() == 0) {
+        sessionId = winningSessionId;
+        return defaultInterval();
+    }
+
+    // Get the smallest positive request, 0 is reserved for HW wakeup
+    QMap<int, unsigned int>::const_iterator it;
+    it = m_intervalMap.begin();
+    highestValue = it.value();
+    winningSessionId = it.key();
+
+    for (++it; it != m_intervalMap.constEnd(); ++it) {
+        if ((it.value() < highestValue) && (it.value() > 0)) {
+            highestValue = it.value();
+            winningSessionId = it.key();
+        }
+    }
+
+    sessionId = winningSessionId;
+    return highestValue > 0 ? highestValue : defaultInterval();
+}
+
+bool GyroAdaptorEvdev::startSensor()
+{
+    if (!powerStatePath_.isEmpty()) {
+        writeToFile(powerStatePath_, "1");
+    }
+    if (SysfsAdaptor::startSensor()) {
+        return true;
+    }
+    return false;
+}
+
+void GyroAdaptorEvdev::stopSensor()
+{
+    if (!powerStatePath_.isEmpty()) {
+        writeToFile(powerStatePath_, "0");
+    }
+
+    SysfsAdaptor::stopSensor();
+}
+
+bool GyroAdaptorEvdev::standby()
+{
+    if (SysfsAdaptor::standby()) {
+        stopSensor();
+        return true;
+    }
+    return false;
+}
+
+bool GyroAdaptorEvdev::resume()
+{
+    if (SysfsAdaptor::resume()) {
+        startSensor();
+        return true;
+    }
+    return false;
+}

--- a/adaptors/gyroscopeadaptor-evdev/gyroevdevadaptor.h
+++ b/adaptors/gyroscopeadaptor-evdev/gyroevdevadaptor.h
@@ -1,0 +1,78 @@
+/**
+   @file gyroevdevadaptor.h
+   @brief Contains GyroAdaptorEvdev.
+
+   <p>
+   Copyright (C) 2009-2010 Nokia Corporation
+   Copyright (C) 2015 Jolla
+
+   @author Lorn Potter <lorn.potter@jolla.com>
+   @author Timo Rongas <ext-timo.2.rongas@nokia.com>
+   @author Markus Lehtonen <markus.lehtonen@nokia.com>
+   Sensord is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License
+   version 2.1 as published by the Free Software Foundation.
+
+   Sensord is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Sensord.  If not, see <http://www.gnu.org/licenses/>.
+   </p>
+*/
+#ifndef GYROEVDEVADAPTOR_H
+#define GYROEVDEVADAPTOR_H
+
+#include "inputdevadaptor.h"
+#include "deviceadaptorringbuffer.h"
+#include "datatypes/orientationdata.h"
+#include <QTime>
+
+class GyroAdaptorEvdev : public InputDevAdaptor
+{
+    Q_OBJECT
+public:
+    /**
+     * Factory method for gaining a new instance of AccelerometerAdaptor class.
+     * @param id Identifier for the adaptor.
+     */
+    static DeviceAdaptor* factoryMethod(const QString& id)
+    {
+        return new GyroAdaptorEvdev(id);
+    }
+
+    virtual bool startSensor();
+
+    virtual void stopSensor();
+
+    virtual bool standby();
+
+    virtual bool resume();
+
+protected:
+    /**
+     * Constructor.
+     * @param id Identifier for the adaptor.
+     */
+    GyroAdaptorEvdev(const QString& id);
+    ~GyroAdaptorEvdev();
+
+    /**
+     * Reimplement to allow for 0 interval to be the slowest entry.
+     */
+    virtual unsigned int evaluateIntervalRequests(int& sessionId) const;
+
+private:
+    DeviceAdaptorRingBuffer<TimedXyzData>* gyroscopeBuffer_;
+
+    void interpretEvent(int src, struct input_event *ev);
+    void commitOutput(struct input_event *ev);
+    void interpretSync(int src, struct input_event *ev);
+    QByteArray powerStatePath_;
+    TimedXyzData gyroValue_;
+
+};
+
+#endif

--- a/adaptors/gyroscopeadaptor-evdev/gyroscopeadaptor-evdev.pro
+++ b/adaptors/gyroscopeadaptor-evdev/gyroscopeadaptor-evdev.pro
@@ -1,0 +1,9 @@
+TARGET = gyroadaptor-evdev
+
+HEADERS += gyroevdevadaptor.h \
+           gyroadaptor-evdevplugin.h
+
+SOURCES += gyroevdevadaptor.cpp \
+           gyroadaptor-evdevplugin.cpp
+
+include( ../adaptor-config.pri )

--- a/adaptors/magnetometeradaptor-evdev/magnetometeradaptor-evdev.pro
+++ b/adaptors/magnetometeradaptor-evdev/magnetometeradaptor-evdev.pro
@@ -1,0 +1,9 @@
+TARGET = magnetometeradaptor-evdev
+
+HEADERS += magnetometerevdevadaptor.h \
+           magnetometeradaptor-evdevplugin.h
+
+SOURCES += magnetometerevdevadaptor.cpp \
+           magnetometeradaptor-evdevplugin.cpp
+
+include( ../adaptor-config.pri )

--- a/adaptors/magnetometeradaptor-evdev/magnetometeradaptor-evdevplugin.cpp
+++ b/adaptors/magnetometeradaptor-evdev/magnetometeradaptor-evdevplugin.cpp
@@ -1,0 +1,43 @@
+/**
+   @file magnetometeradaptor-evdevplugin.cpp
+   @brief Contains MagnetometerAdaptorEvdevPlugin.
+
+   <p>
+   Copyright (C) 2009-2010 Nokia Corporation
+   Copyright (C) 2015 Jolla
+
+   @author Lorn Potter <lorn.potter@jolla.com>
+   @author Timo Rongas <ext-timo.2.rongas@nokia.com>
+   @author Markus Lehtonen <markus.lehtonen@nokia.com>
+   This file is part of Sensord.
+
+   Sensord is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License
+   version 2.1 as published by the Free Software Foundation.
+
+   Sensord is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Sensord.  If not, see <http://www.gnu.org/licenses/>.
+   </p>
+*/
+
+
+#include "magnetometeradaptor-evdevplugin.h"
+#include "magnetometerevdevadaptor.h"
+#include "sensormanager.h"
+#include "logging.h"
+
+void MagnetometerAdaptorEvdevPlugin::Register(class Loader&)
+{
+    sensordLogD() << "registering magnetometeradaptor-evdev";
+    SensorManager& sm = SensorManager::instance();
+    sm.registerDeviceAdaptor<MagAdaptorEvdev>("magnetometeradaptor");
+}
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+Q_EXPORT_PLUGIN2(magnetometeradaptor-evdev, MagnetometerAdaptorEvdevPlugin)
+#endif

--- a/adaptors/magnetometeradaptor-evdev/magnetometeradaptor-evdevplugin.h
+++ b/adaptors/magnetometeradaptor-evdev/magnetometeradaptor-evdevplugin.h
@@ -1,0 +1,44 @@
+/**
+   @file alsadaptor-sysfsplugin.h
+   @brief Plugin for ALSAdaptorSysfs
+
+   <p>
+   Copyright (C) 2009-2010 Nokia Corporation
+   Copyright (C) 2015 Jolla
+
+   @author Lorn Potter <lorn.potter@jolla.com>
+   @author Timo Rongas <ext-timo.2.rongas@nokia.com>
+   @author Markus Lehtonen <markus.lehtonen@nokia.com>
+   This file is part of Sensord.
+
+   Sensord is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License
+   version 2.1 as published by the Free Software Foundation.
+
+   Sensord is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Sensord.  If not, see <http://www.gnu.org/licenses/>.
+   </p>
+*/
+
+#ifndef MAGADAPTOR_EVDEVPLUGIN_H
+#define MAGADAPTOR_EVDEVPLUGIN_H
+
+#include "plugin.h"
+
+class MagnetometerAdaptorEvdevPlugin : public Plugin
+{
+    Q_OBJECT
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+    Q_PLUGIN_METADATA(IID "com.nokia.SensorService.Plugin/1.0")
+#endif
+
+private:
+    void Register(class Loader& l);
+};
+
+#endif

--- a/adaptors/magnetometeradaptor-evdev/magnetometerevdevadaptor.cpp
+++ b/adaptors/magnetometeradaptor-evdev/magnetometerevdevadaptor.cpp
@@ -1,0 +1,159 @@
+/**
+   @file magnetometerevdevadaptor.cpp
+   @brief Contains MagAdaptorEvdev.
+
+   <p>
+   Copyright (C) 2009-2010 Nokia Corporation
+   Copyright (C) 2015 Jolla
+
+   @author Lorn Potter <lorn.potter@jolla.com>
+   @author Timo Rongas <ext-timo.2.rongas@nokia.com>
+   @author Markus Lehtonen <markus.lehtonen@nokia.com>
+   This file is part of Sensord.
+
+   Sensord is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License
+   version 2.1 as published by the Free Software Foundation.
+
+   Sensord is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Sensord.  If not, see <http://www.gnu.org/licenses/>.
+   </p>
+*/
+
+#include "magnetometerevdevadaptor.h"
+#include "config.h"
+#include "logging.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/input.h>
+#include <unistd.h>
+#include <QMap>
+
+#include "datatypes/utils.h"
+
+MagAdaptorEvdev::MagAdaptorEvdev(const QString& id) :
+    InputDevAdaptor(id, 1)
+{
+    magnetometerBuffer_ = new DeviceAdaptorRingBuffer<TimedXyzData>(1);
+    setAdaptedSensor("magnetometer", "Internal magnetometer coordinates", magnetometerBuffer_);
+    setDescription("Input device magnetometer adaptor");
+    powerStatePath_ = Config::configuration()->value("magnetometer/powerstate_path").toByteArray();
+  //  introduceAvailableDataRange(DataRange(0, 4095, 1));
+    setDefaultInterval(10);
+}
+
+MagAdaptorEvdev::~MagAdaptorEvdev()
+{
+    delete magnetometerBuffer_;
+}
+
+void MagAdaptorEvdev::interpretEvent(int src, struct input_event *ev)
+{
+    Q_UNUSED(src);
+
+    switch (ev->type) {
+    case EV_ABS:
+    case EV_REL:
+        switch (ev->code) {
+        case ABS_X:
+            magValue_.x_ = ev->value;
+            break;
+        case ABS_Y:
+            magValue_.y_ = ev->value;
+            break;
+        case ABS_Z:
+            magValue_.z_ = ev->value;
+            break;
+        }
+        break;
+    }
+}
+
+void MagAdaptorEvdev::interpretSync(int src, struct input_event *ev)
+{
+    Q_UNUSED(src);
+    commitOutput(ev);
+}
+
+void MagAdaptorEvdev::commitOutput(struct input_event *ev)
+{
+    TimedXyzData* magData = magnetometerBuffer_->nextSlot();
+    magData->x_ = magValue_.x_;
+    magData->y_ = magValue_.y_;
+    magData->z_ = magValue_.z_;
+
+    magData->timestamp_ = Utils::getTimeStamp(&(ev->time));
+
+    magnetometerBuffer_->commit();
+    magnetometerBuffer_->wakeUpReaders();
+}
+
+unsigned int MagAdaptorEvdev::evaluateIntervalRequests(int& sessionId) const
+{
+    unsigned int highestValue = 0;
+    int winningSessionId = -1;
+
+    if (m_intervalMap.size() == 0) {
+        sessionId = winningSessionId;
+        return defaultInterval();
+    }
+
+    // Get the smallest positive request, 0 is reserved for HW wakeup
+    QMap<int, unsigned int>::const_iterator it;
+    it = m_intervalMap.begin();
+    highestValue = it.value();
+    winningSessionId = it.key();
+
+    for (++it; it != m_intervalMap.constEnd(); ++it) {
+        if ((it.value() < highestValue) && (it.value() > 0)) {
+            highestValue = it.value();
+            winningSessionId = it.key();
+        }
+    }
+
+    sessionId = winningSessionId;
+    return highestValue > 0 ? highestValue : defaultInterval();
+}
+
+bool MagAdaptorEvdev::startSensor()
+{
+    if (!powerStatePath_.isEmpty()) {
+        writeToFile(powerStatePath_, "1");
+    }
+    if (SysfsAdaptor::startSensor()) {
+        return true;
+    }
+    return false;
+}
+
+void MagAdaptorEvdev::stopSensor()
+{
+    if (!powerStatePath_.isEmpty()) {
+        writeToFile(powerStatePath_, "0");
+    }
+
+    SysfsAdaptor::stopSensor();
+}
+
+bool MagAdaptorEvdev::standby()
+{
+    if (SysfsAdaptor::standby()) {
+        stopSensor();
+        return true;
+    }
+    return false;
+}
+
+bool MagAdaptorEvdev::resume()
+{
+    if (SysfsAdaptor::resume()) {
+        startSensor();
+        return true;
+    }
+    return false;
+}

--- a/adaptors/magnetometeradaptor-evdev/magnetometerevdevadaptor.h
+++ b/adaptors/magnetometeradaptor-evdev/magnetometerevdevadaptor.h
@@ -1,0 +1,80 @@
+/**
+   @file magnetometeradaptor-evdevplugin.cpp
+   @brief Contains MagnetometerAdaptorEvdevPlugin.
+
+   <p>
+   Copyright (C) 2009-2010 Nokia Corporation
+   Copyright (C) 2015 Jolla
+
+   @author Lorn Potter <lorn.potter@jolla.com>
+   @author Timo Rongas <ext-timo.2.rongas@nokia.com>
+   @author Markus Lehtonen <markus.lehtonen@nokia.com>
+   This file is part of Sensord.
+
+   Sensord is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License
+   version 2.1 as published by the Free Software Foundation.
+
+   Sensord is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Sensord.  If not, see <http://www.gnu.org/licenses/>.
+   </p>
+*/
+
+#ifndef MAGEVDEVADAPTOR_H
+#define MAGEVDEVADAPTOR_H
+
+#include "inputdevadaptor.h"
+#include "deviceadaptorringbuffer.h"
+#include "datatypes/orientationdata.h"
+#include <QTime>
+
+class MagAdaptorEvdev : public InputDevAdaptor
+{
+    Q_OBJECT
+public:
+    /**
+     * Factory method for gaining a new instance of AccelerometerAdaptor class.
+     * @param id Identifier for the adaptor.
+     */
+    static DeviceAdaptor* factoryMethod(const QString& id)
+    {
+        return new MagAdaptorEvdev(id);
+    }
+
+    virtual bool startSensor();
+
+    virtual void stopSensor();
+
+    virtual bool standby();
+
+    virtual bool resume();
+
+protected:
+    /**
+     * Constructor.
+     * @param id Identifier for the adaptor.
+     */
+    MagAdaptorEvdev(const QString& id);
+    ~MagAdaptorEvdev();
+
+    /**
+     * Reimplement to allow for 0 interval to be the slowest entry.
+     */
+    virtual unsigned int evaluateIntervalRequests(int& sessionId) const;
+
+private:
+    DeviceAdaptorRingBuffer<TimedXyzData>* magnetometerBuffer_;
+
+    void interpretEvent(int src, struct input_event *ev);
+    void commitOutput(struct input_event *ev);
+    void interpretSync(int src, struct input_event *ev);
+    QByteArray powerStatePath_;
+    TimedXyzData magValue_;
+};
+
+#endif

--- a/config/sensord-tbj.conf
+++ b/config/sensord-tbj.conf
@@ -1,0 +1,31 @@
+[plugins]
+accelerometeradaptor = accelerometeradaptor
+alsadaptor = alsadaptor-evdev
+#proximityadaptor = hybrisproximityadaptor
+magnetometeradaptor = magnetometeradaptor-evdev
+gyroscopeadaptor = gyroadaptor-evdev
+orientationadaptor = hybrisorientationadaptor
+
+[accelerometer]
+input_match = accel
+poll_file = /sys/bus/i2c/devices/3-000f/poll
+
+[als]
+input_match = jsa1212_als
+poll_file = /sys/bus/i2c/devices/3-0044/als_poll
+powerstate_path = /sys/bus/i2c/devices/3-0044/als_enable
+
+[magnetometer]
+input_match = comp
+poll_file = /sys/bus/i2c/devices/3-000c/poll
+powerstate_path = /sys/bus/i2c/devices/3-000c/enable
+
+[gyroscope]
+input_match = gyro
+poll_file = /sys/bus/i2c/devices/3-0068/poll
+powerstate_path = /sys/bus/i2c/devices/3-0068/enable
+
+[global]
+device_sys_path = /dev/input/event%1
+#device_poll_file_path = /sys/class/input/input%1/poll
+


### PR DESCRIPTION
Adaptors are generic in nature and can be used by any device.

- config for tbj that makes use of evdev adaptors