### PR TITLE
Fix hybris compass calibration level.

### DIFF
--- a/adaptors/hybrisorientationadaptor/hybrisorientationadaptor.cpp
+++ b/adaptors/hybrisorientationadaptor/hybrisorientationadaptor.cpp
@@ -80,7 +80,7 @@ void HybrisOrientationAdaptor::processSample(const sensors_event_t& data)
         d->level_ = 0;
         break;
     default:
-        d->level_ = data.orientation.status / 3;
+        d->level_ = data.orientation.status;
         break;
     };
 


### PR DESCRIPTION
This division happens in QtSensors sensorfw backend, no need to do it
here.
Fixes "compass sensor calibration never gets above low"