### PR TITLE
[sensorfw] get compass working Fixes MER#882

### DIFF
--- a/adaptors/hybrisaccelerometer/hybrisaccelerometeradaptor.cpp
+++ b/adaptors/hybrisaccelerometer/hybrisaccelerometeradaptor.cpp
@@ -23,6 +23,8 @@
 #include "datatypes/utils.h"
 #include <hardware/sensors.h>
 
+#define GRAVITY_RECIPROCAL_THOUSANDS 101.971621298
+
 HybrisAccelerometerAdaptor::HybrisAccelerometerAdaptor(const QString& id) :
     HybrisAdaptor(id,SENSOR_TYPE_ACCELEROMETER)
 {
@@ -55,15 +57,14 @@ void HybrisAccelerometerAdaptor::stopSensor()
 
 void HybrisAccelerometerAdaptor::processSample(const sensors_event_t& data)
 {
-
     AccelerationData *d = buffer->nextSlot();
     d->timestamp_ = quint64(data.timestamp * .001);
     // sensorfw wants milli-G'
-    d->x_ = -(data.data[0] / 9.80665 * 1000);
-    d->y_ = -(data.data[1] / 9.80665 * 1000);
-    d->z_ = -(data.data[2] / 9.80665 * 1000);
-//  qt's sensorfw plugin expects G == 9.81286, but it should be
-    //9.80665
+
+    d->x_ = data.acceleration.x * GRAVITY_RECIPROCAL_THOUSANDS;
+    d->y_ = data.acceleration.y * GRAVITY_RECIPROCAL_THOUSANDS;
+    d->z_ = data.acceleration.z * GRAVITY_RECIPROCAL_THOUSANDS;
+
     buffer->commit();
     buffer->wakeUpReaders();
 }

--- a/adaptors/hybrisgyroscopeadaptor/hybrisgyroscopeadaptor.cpp
+++ b/adaptors/hybrisgyroscopeadaptor/hybrisgyroscopeadaptor.cpp
@@ -24,6 +24,8 @@
 #include <hardware/sensors.h>
 #include <math.h>
 
+#define RADIANS_TO_DEGREESECONDS 57295.7795
+#define RADIANS_TO_DEGREES 57.2957795
 
 HybrisGyroscopeAdaptor::HybrisGyroscopeAdaptor(const QString& id) :
     HybrisAdaptor(id,SENSOR_TYPE_GYROSCOPE)
@@ -61,10 +63,9 @@ void HybrisGyroscopeAdaptor::processSample(const sensors_event_t& data)
 
     TimedXyzData *d = buffer->nextSlot();
     d->timestamp_ = quint64(data.timestamp * .001);
-    d->x_ = (data.acceleration.x) * 57295.7795;
-    d->y_ = (data.acceleration.y) * 57295.7795;
-    d->z_ = (data.acceleration.z) * 57295.7795;
-
+    d->x_ = (data.gyro.x) * RADIANS_TO_DEGREES * 1000;
+    d->y_ = (data.gyro.y) * RADIANS_TO_DEGREES * 1000;
+    d->z_ = (data.gyro.z) * RADIANS_TO_DEGREES * 1000;
     buffer->commit();
     buffer->wakeUpReaders();
 }

--- a/adaptors/hybrismagnetometeradaptor/hybrismagnetometeradaptor.h
+++ b/adaptors/hybrismagnetometeradaptor/hybrismagnetometeradaptor.h
@@ -55,7 +55,7 @@ protected:
     void init();
 
 private:
-    DeviceAdaptorRingBuffer<TimedXyzData>* buffer;
+    DeviceAdaptorRingBuffer<CalibratedMagneticFieldData>* buffer;
     int sensorType;
 
 };

--- a/adaptors/hybrisorientationadaptor/hybrisorientationadaptor.cpp
+++ b/adaptors/hybrisorientationadaptor/hybrisorientationadaptor.cpp
@@ -44,7 +44,7 @@ HybrisOrientationAdaptor::HybrisOrientationAdaptor(const QString& id) :
     HybrisAdaptor(id,SENSOR_TYPE_ORIENTATION)
 {
     buffer = new DeviceAdaptorRingBuffer<CompassData>(1);
-    setAdaptedSensor("orientation", "Internal orientation coordinates", buffer);
+    setAdaptedSensor("hybrisorientation", "Internal orientation coordinates", buffer);
 
     setDescription("Hybris orientation");
 //    setDefaultInterval(50);
@@ -74,15 +74,9 @@ void HybrisOrientationAdaptor::processSample(const sensors_event_t& data)
 {
     CompassData *d = buffer->nextSlot();
     d->timestamp_ = quint64(data.timestamp * .001);
-    d->degrees_ = data.data[0] * 1000; //azimuth
-    switch (data.orientation.status) {
-    case SENSOR_STATUS_UNRELIABLE:
-        d->level_ = 0;
-        break;
-    default:
-        d->level_ = data.orientation.status;
-        break;
-    };
+    d->degrees_ = data.orientation.azimuth; //azimuth
+    d->rawDegrees_ = d->degrees_;
+    d->level_ = data.orientation.status;
 
     buffer->commit();
     buffer->wakeUpReaders();

--- a/adaptors/magnetometeradaptor-ascii/magnetometeradaptor-ascii.cpp
+++ b/adaptors/magnetometeradaptor-ascii/magnetometeradaptor-ascii.cpp
@@ -43,7 +43,7 @@ MagnetometerAdaptorAscii::MagnetometerAdaptorAscii(const QString& id) :
     SysfsAdaptor(id, SysfsAdaptor::IntervalMode)
 {
     memset(buf, 0x0, 32);
-    magnetBuffer_ = new DeviceAdaptorRingBuffer<TimedXyzData>(1);
+    magnetBuffer_ = new DeviceAdaptorRingBuffer<CalibratedMagneticFieldData>(1);
     setAdaptedSensor("magnetometer", "ak8974 ascii", magnetBuffer_);
 }
 
@@ -65,7 +65,7 @@ void MagnetometerAdaptorAscii::processSample(int, int fd)
 
     sscanf(buf, "%hx:%hx:%hx\n", &x, &y, &z);
 
-    TimedXyzData* pos = magnetBuffer_->nextSlot();
+    CalibratedMagneticFieldData* pos = magnetBuffer_->nextSlot();
     pos->x_ = (short)x;
     pos->y_ = (short)y;
     pos->z_ = (short)z;

--- a/adaptors/magnetometeradaptor-ascii/magnetometeradaptor-ascii.h
+++ b/adaptors/magnetometeradaptor-ascii/magnetometeradaptor-ascii.h
@@ -35,6 +35,7 @@
 #include "sysfsadaptor.h"
 #include "deviceadaptorringbuffer.h"
 #include "datatypes/timedunsigned.h"
+#include "datatypes/orientationdata.h"
 
 class MagnetometerAdaptorAscii : public SysfsAdaptor
 {
@@ -53,7 +54,7 @@ private:
     void processSample(int pathId, int fd);
     char buf[32];
 
-    DeviceAdaptorRingBuffer<TimedXyzData>* magnetBuffer_;
+    DeviceAdaptorRingBuffer<CalibratedMagneticFieldData>* magnetBuffer_;
 };
 
 #endif

--- a/adaptors/magnetometeradaptor-evdev/magnetometerevdevadaptor.cpp
+++ b/adaptors/magnetometeradaptor-evdev/magnetometerevdevadaptor.cpp
@@ -39,7 +39,7 @@
 MagAdaptorEvdev::MagAdaptorEvdev(const QString& id) :
     InputDevAdaptor(id, 1)
 {
-    magnetometerBuffer_ = new DeviceAdaptorRingBuffer<TimedXyzData>(1);
+    magnetometerBuffer_ = new DeviceAdaptorRingBuffer<CalibratedMagneticFieldData>(1);
     setAdaptedSensor("magnetometer", "Internal magnetometer coordinates", magnetometerBuffer_);
     setDescription("Input device magnetometer adaptor");
     powerStatePath_ = Config::configuration()->value("magnetometer/powerstate_path").toByteArray();
@@ -82,7 +82,7 @@ void MagAdaptorEvdev::interpretSync(int src, struct input_event *ev)
 
 void MagAdaptorEvdev::commitOutput(struct input_event *ev)
 {
-    TimedXyzData* magData = magnetometerBuffer_->nextSlot();
+    CalibratedMagneticFieldData* magData = magnetometerBuffer_->nextSlot();
     magData->x_ = magValue_.x_;
     magData->y_ = magValue_.y_;
     magData->z_ = magValue_.z_;

--- a/adaptors/magnetometeradaptor-evdev/magnetometerevdevadaptor.h
+++ b/adaptors/magnetometeradaptor-evdev/magnetometerevdevadaptor.h
@@ -68,13 +68,13 @@ protected:
     virtual unsigned int evaluateIntervalRequests(int& sessionId) const;
 
 private:
-    DeviceAdaptorRingBuffer<TimedXyzData>* magnetometerBuffer_;
+    DeviceAdaptorRingBuffer<CalibratedMagneticFieldData>* magnetometerBuffer_;
 
     void interpretEvent(int src, struct input_event *ev);
     void commitOutput(struct input_event *ev);
     void interpretSync(int src, struct input_event *ev);
     QByteArray powerStatePath_;
-    TimedXyzData magValue_;
+    CalibratedMagneticFieldData magValue_;
 };
 
 #endif

--- a/adaptors/magnetometeradaptor-ncdk/magnetometeradaptor-ncdk.cpp
+++ b/adaptors/magnetometeradaptor-ncdk/magnetometeradaptor-ncdk.cpp
@@ -37,7 +37,7 @@ MagnetometerAdaptorNCDK::MagnetometerAdaptorNCDK(const QString& id) :
     intervalCompensation_ = Config::configuration()->value<int>("magnetometer/interval_compensation", 0);
     powerStateFilePath_ = Config::configuration()->value<QByteArray>("magnetometer/path_power_state", "");
     sensAdjFilePath_ = Config::configuration()->value<QByteArray>("magnetometer/path_sens_adjust", "");
-    magnetometerBuffer_ = new DeviceAdaptorRingBuffer<TimedXyzData>(128);
+    magnetometerBuffer_ = new DeviceAdaptorRingBuffer<CalibratedMagneticFieldData>(128);
     setAdaptedSensor("magnetometer", "Internal magnetometer coordinates", magnetometerBuffer_);
     setDescription("Magnetometer adaptor (ak8975) for NCDK");
 
@@ -84,7 +84,7 @@ void MagnetometerAdaptorNCDK::processSample(int pathId, int fd)
 
     sensordLogT() << "Magnetometer Reading: " << x << ", " << y << ", " << z;
 
-    TimedXyzData* sample = magnetometerBuffer_->nextSlot();
+    CalibratedMagneticFieldData* sample = magnetometerBuffer_->nextSlot();
 
     sample->timestamp_ = Utils::getTimeStamp();
     sample->x_ = x;
@@ -159,7 +159,7 @@ bool MagnetometerAdaptorNCDK::setInterval(const unsigned int value, const int se
 {
     if(intervalCompensation_)
     {
-        return SysfsAdaptor::setInterval(value > intervalCompensation_ ? value - intervalCompensation_ : 0, sessionId);
+        return SysfsAdaptor::setInterval((int)value > intervalCompensation_ ? value - intervalCompensation_ : 0, sessionId);
     }
     return SysfsAdaptor::setInterval(value, sessionId);
 }

--- a/adaptors/magnetometeradaptor-ncdk/magnetometeradaptor-ncdk.h
+++ b/adaptors/magnetometeradaptor-ncdk/magnetometeradaptor-ncdk.h
@@ -29,7 +29,7 @@
 #include "deviceadaptorringbuffer.h"
 #include "datatypes/genericdata.h"
 #include <QString>
-
+#include "datatypes/orientationdata.h"
 
 class MagnetometerAdaptorNCDK : public SysfsAdaptor
 {
@@ -76,7 +76,7 @@ private:
 
     int x_adj, y_adj, z_adj;
     bool powerState_;
-    DeviceAdaptorRingBuffer<TimedXyzData>* magnetometerBuffer_;
+    DeviceAdaptorRingBuffer<CalibratedMagneticFieldData>* magnetometerBuffer_;
 
     bool setPowerState(bool value) const;
     void getSensitivityAdjustment(int &x, int &y, int &z) const;

--- a/adaptors/magnetometeradaptor/magnetometeradaptor.cpp
+++ b/adaptors/magnetometeradaptor/magnetometeradaptor.cpp
@@ -47,7 +47,7 @@ MagnetometerAdaptor::MagnetometerAdaptor(const QString& id) :
     SysfsAdaptor(id, SysfsAdaptor::IntervalMode, false)
 {
     intervalCompensation_ = Config::configuration()->value<int>("magnetometer/interval_compensation", 0);
-    magnetometerBuffer_ = new DeviceAdaptorRingBuffer<TimedXyzData>(1);
+    magnetometerBuffer_ = new DeviceAdaptorRingBuffer<CalibratedMagneticFieldData>(1);
     setAdaptedSensor("magnetometer", "Internal magnetometer coordinates", magnetometerBuffer_);
     overflowLimit_ = Config::configuration()->value<int>("magnetometer/overflow_limit", 8000);
     setDescription("Input device Magnetometer adaptor (ak897x)");
@@ -78,7 +78,7 @@ void MagnetometerAdaptor::processSample(int pathId, int fd)
 
     sensordLogT() << "Magnetometer reading: " << mag_data.x << ", " << mag_data.y << ", " << mag_data.z;
 
-    TimedXyzData* sample = magnetometerBuffer_->nextSlot();
+    CalibratedMagneticFieldData* sample = magnetometerBuffer_->nextSlot();
 
     sample->timestamp_ = Utils::getTimeStamp();
     sample->x_ = mag_data.x;

--- a/adaptors/magnetometeradaptor/magnetometeradaptor.h
+++ b/adaptors/magnetometeradaptor/magnetometeradaptor.h
@@ -32,6 +32,7 @@
 #include "deviceadaptorringbuffer.h"
 #include "datatypes/genericdata.h"
 #include <QString>
+#include "datatypes/orientationdata.h"
 
 /**
  * @brief Adaptor for internal magnetometer.
@@ -90,7 +91,7 @@ private:
      */
     int overflowLimit() const;
 
-    DeviceAdaptorRingBuffer<TimedXyzData>* magnetometerBuffer_;
+    DeviceAdaptorRingBuffer<CalibratedMagneticFieldData>* magnetometerBuffer_;
     int intervalCompensation_;
     int overflowLimit_;
 };

--- a/chains/accelerometerchain/accelerometerchain.cpp
+++ b/chains/accelerometerchain/accelerometerchain.cpp
@@ -75,8 +75,11 @@ AccelerometerChain::AccelerometerChain(const QString& id) :
     filterBin_->add(outputBuffer_, "buffer");
 
     // Join filterchain buffers
-    filterBin_->join("accelerometer", "source", "acccoordinatealigner", "sink");
-    filterBin_->join("acccoordinatealigner", "source", "buffer", "sink");
+    if (!filterBin_->join("accelerometer", "source", "acccoordinatealigner", "sink"))
+    qDebug() << Q_FUNC_INFO << "accelerometer/acccoordinatealigner join failed";
+
+    if (!filterBin_->join("acccoordinatealigner", "source", "buffer", "sink"))
+    qDebug() << Q_FUNC_INFO << "acccoordinatealigner/buffer join failed";
 
     // Join datasources to the chain
     connectToSource(accelerometerAdaptor_, "accelerometer", accelerometerReader_);

--- a/chains/compasschain/compasschain.pro
+++ b/chains/compasschain/compasschain.pro
@@ -10,6 +10,11 @@ SOURCES += compasschain.cpp   \
            compassfilter.cpp \
            orientationfilter.cpp
 
-INCLUDEPATH += ../../filters/coordinatealignfilter
+INCLUDEPATH += ../../filters/coordinatealignfilter \
+               ../../filters/downsamplefilter \
+               ../../filters/avgaccfilter \
+               ../../chains/magcalibrationchain \
+               ../../filters/magcoordinatealignfilter \
+               ../../filters/declinationfilter
 
 include( ../chain-config.pri )

--- a/chains/compasschain/compasschainplugin.cpp
+++ b/chains/compasschain/compasschainplugin.cpp
@@ -24,6 +24,7 @@
 #include "orientationfilter.h"
 #include "sensormanager.h"
 #include "logging.h"
+#include "config.h"
 
 void CompassChainPlugin::Register(class Loader&)
 {
@@ -36,8 +37,12 @@ void CompassChainPlugin::Register(class Loader&)
 }
 
 QStringList CompassChainPlugin::Dependencies() {
-//    return QString("accelerometerchain:magcalibrationchain:declinationfilter:downsamplefilter:avgaccfilterr").split(":", QString::SkipEmptyParts);
-    return QString("accelerometerchain:magcalibrationchain:declinationfilter:downsamplefilter:avgaccfilter:orientationadaptor").split(":", QString::SkipEmptyParts);
+    QByteArray orientationConfiguration = Config::configuration()->value("plugins/orientationadaptor").toByteArray();
+    if (orientationConfiguration.isEmpty()) {
+        return QString("accelerometerchain:magcalibrationchain:declinationfilter:downsamplefilter:avgaccfilter").split(":", QString::SkipEmptyParts);
+    } else {
+        return QString("accelerometerchain:magcalibrationchain:declinationfilter:downsamplefilter:avgaccfilter:orientationadaptor").split(":", QString::SkipEmptyParts);
+    }
 }
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)

--- a/chains/compasschain/compassfilter.h
+++ b/chains/compasschain/compassfilter.h
@@ -49,19 +49,21 @@ private:
     void magDataAvailable(unsigned, const CalibratedMagneticFieldData*);
     void accelDataAvailable(unsigned, const AccelerationData*);
 
-    int factor;
     CalibratedMagneticFieldData magData;
 
-    qreal magRX;
-    qreal magRY;
-    qreal magRZ;
+    qreal magX;
+    qreal magY;
+    qreal magZ;
+    qreal oldMagX;
+    qreal oldMagY;
+    qreal oldMagZ;
 
-    qreal adjX;
-    qreal adjY;
-    qreal adjZ;
-
-    qreal level;
-    qreal oldHeading;
+    int level;
+    int oldHeading;
+    QList <int> averagingBuffer;
+    QList <const CalibratedMagneticFieldData *> magAvgBuffer;
+    QList <const AccelerationData *> accelAvgBuffer;
+//    MagAvgBuffer magAvgBuffer;
 };
 
 #endif

--- a/chains/compasschain/orientationfilter.cpp
+++ b/chains/compasschain/orientationfilter.cpp
@@ -23,21 +23,16 @@
 
 
 OrientationFilter::OrientationFilter()
-    : orientDataSink(this, &OrientationFilter::orientDataAvailable),
-      level(0) //presume this is fully calibrated
-{
+    : orientDataSink(this, &OrientationFilter::orientDataAvailable){
     addSink(&orientDataSink, "orientsink");
     addSource(&magSource, "magnorthangle");
 }
 
 void OrientationFilter::orientDataAvailable(unsigned, const CompassData *data)
 {
-    CompassData compassData; //north angle
     compassData.timestamp_ = data->timestamp_;
-    compassData.degrees_ = data->degrees_ * .001;
-    if (data->level_ > 0 && data->level_ < 3.1)
-        compassData.level_ = data->level_;
-    else
-        compassData.level_ = level;
+    compassData.degrees_ =  data->degrees_;
+    compassData.rawDegrees_ = data->rawDegrees_;
+    compassData.level_ = data->level_;
     magSource.propagate(1, &compassData);
 }

--- a/chains/compasschain/orientationfilter.h
+++ b/chains/compasschain/orientationfilter.h
@@ -45,8 +45,9 @@ private:
 
     Sink<OrientationFilter, CompassData> orientDataSink;
     void orientDataAvailable(unsigned, const CompassData*);
-    qreal level;
-    qreal oldHeading;
+
+    CompassData compassData; //north angle
+
 };
 
 #endif

--- a/chains/magcalibrationchain/calibrationfilter.h
+++ b/chains/magcalibrationchain/calibrationfilter.h
@@ -26,8 +26,9 @@
 #include "orientationdata.h"
 #include "filter.h"
 
+#include <QFile>
 
-class CalibrationFilter : public QObject, public Filter<TimedXyzData, CalibrationFilter, CalibratedMagneticFieldData>
+class CalibrationFilter : public QObject, public Filter<CalibratedMagneticFieldData, CalibrationFilter, CalibratedMagneticFieldData>
 {
     Q_OBJECT
 
@@ -44,20 +45,40 @@ protected:
 
 private:
 
-    Sink<CalibrationFilter, TimedXyzData> magDataSink;
+    Sink<CalibrationFilter, CalibratedMagneticFieldData> magDataSink;
 
     Source<CalibratedMagneticFieldData> magSource;
-
-    void magDataAvailable(unsigned, const TimedXyzData * );
+    void magDataAvailable(unsigned, const CalibratedMagneticFieldData * );
 
     CalibratedMagneticFieldData magData;
+    CalibratedMagneticFieldData transformed;
+
     QList <QPair<int,int> > minMaxList;
 
-    qreal oldX;
-    qreal oldY;
-    qreal oldZ;
+    qreal offsetX;
+    qreal offsetY;
+    qreal offsetZ;
+
+    qreal xScale;
+    qreal yScale;
+    qreal zScale;
+
+    qreal meanX;
+    qreal meanY;
+    qreal meanZ;
 
     qreal calLevel;
+    int lowPass(int newVal, int oldVal);
+    QList<const CalibratedMagneticFieldData *> *readingBuffer;
+    int bufferPos;
+
+    QFile unCalibratedData;
+    QFile calibratedData;
+    QTextStream stream;
+    QTextStream calibratedStream;
+    int dataPoints;
+    bool manualCalibration;
+
 };
 
 #endif

--- a/chains/magcalibrationchain/magcalibrationchain.h
+++ b/chains/magcalibrationchain/magcalibrationchain.h
@@ -24,7 +24,7 @@
 
 #include "abstractsensor.h"
 #include "abstractchain.h"
-//#include "coordinatealignfilter.h"
+#include "magcoordinatealignfilter.h"
 #include "deviceadaptor.h"
 #include "bufferreader.h"
 #include "filter.h"
@@ -72,16 +72,20 @@ protected:
     ~MagCalibrationChain();
 
 private:
+    bool setMatrixFromString(const QString& str);
+    double aconv_[3][3];
 
     Bin* filterBin;
     DeviceAdaptor *magAdaptor;
 
-    BufferReader<TimedXyzData>  *magReader; //pusher/producer
+    BufferReader<CalibratedMagneticFieldData>  *magReader; //pusher/producer
 
-    FilterBase* magCalFilter;
-    FilterBase* magScaleFilter;
+    FilterBase *magCalFilter;
+    FilterBase *magScaleFilter;
 
+    FilterBase *magCoordinateAlignFilter_;
     RingBuffer<CalibratedMagneticFieldData> *calibratedMagnetometerData; //consumer
+    bool needsCalibration;
 };
 
 #endif // MAGCALIBRATIONCHAIN_H

--- a/chains/magcalibrationchain/magcalibrationchain.pro
+++ b/chains/magcalibrationchain/magcalibrationchain.pro
@@ -10,4 +10,6 @@ SOURCES += magcalibrationchain.cpp \
            magcalibrationchainplugin.cpp
 #        qvector3d.cpp
 
+INCLUDEPATH += ../../filters/magcoordinatealignfilter
+
 include( ../chain-config.pri )

--- a/chains/orientationchain/orientationchain.cpp
+++ b/chains/orientationchain/orientationchain.cpp
@@ -60,10 +60,14 @@ OrientationChain::OrientationChain(const QString& id) :
     filterBin_->add(orientationOutput_, "orientationbuffer");
 
     // Join filterchain buffers
-    filterBin_->join("accelerometer", "source", "orientationinterpreter", "accsink");
-    filterBin_->join("orientationinterpreter", "topedge", "topedgebuffer", "sink");
-    filterBin_->join("orientationinterpreter", "face", "facebuffer", "sink");
-    filterBin_->join("orientationinterpreter", "orientation", "orientationbuffer", "sink");
+    if (!filterBin_->join("accelerometer", "source", "orientationinterpreter", "accsink"))
+        qDebug() << Q_FUNC_INFO << "accelerometer/orientationinterpreter join failed";
+    if (!filterBin_->join("orientationinterpreter", "topedge", "topedgebuffer", "sink"))
+        qDebug() << Q_FUNC_INFO << "orientationinterpreter/topedgebuffer join failed";
+    if (!filterBin_->join("orientationinterpreter", "face", "facebuffer", "sink"))
+        qDebug() << Q_FUNC_INFO << "orientationinterpreter/facebuffer join failed";
+    if (!filterBin_->join("orientationinterpreter", "orientation", "orientationbuffer", "sink"))
+        qDebug() << Q_FUNC_INFO << "orientationinterpreter/orientationbuffer join failed";
 
     // Join datasources to the chain
     connectToSource(accelerometerChain_, "accelerometer", accelerometerReader_);

--- a/config/sensord-hybris.conf
+++ b/config/sensord-hybris.conf
@@ -8,6 +8,12 @@ orientationadaptor = hybrisorientationadaptor
 
 [magnetometer]
 scale_coefficient = 1
+transformation_matrix = "-1,0,0,0,1,0,0,0,1"
+needs_calibration = 0
+
+[accelerometer]
+transformation_matrix = "-1,0,0,0,-1,0,0,0,1"
+
 
 #[magnetometer]
 #dataranges = "-4096=>4096"

--- a/config/sensord-tbj.conf
+++ b/config/sensord-tbj.conf
@@ -9,6 +9,7 @@ orientationadaptor = hybrisorientationadaptor
 [accelerometer]
 input_match = accel
 poll_file = /sys/bus/i2c/devices/3-000f/poll
+transformation_matrix = "-1,0,0,0,-1,0,0,0,-1"
 
 [als]
 input_match = jsa1212_als
@@ -19,6 +20,8 @@ powerstate_path = /sys/bus/i2c/devices/3-0044/als_enable
 input_match = comp
 poll_file = /sys/bus/i2c/devices/3-000c/poll
 powerstate_path = /sys/bus/i2c/devices/3-000c/enable
+transformation_matrix = "1,0,0,0,1,0,0,0,1"
+needs_calibration = 1
 
 [gyroscope]
 input_match = gyro

--- a/core/hybrisadaptor.cpp
+++ b/core/hybrisadaptor.cpp
@@ -347,6 +347,9 @@ HybrisAdaptor::~HybrisAdaptor()
 void HybrisAdaptor::init()
 {
     sensorHandle = hybrisManager()->handleForType(sensorType);
+    if (sensorHandle == -1) {
+        setValid(false);
+    }
     maxRange = hybrisManager()->maxRange(sensorType);
     minDelay = hybrisManager()->minDelay(sensorType);
     if (minDelay > 1000)
@@ -372,7 +375,6 @@ bool HybrisAdaptor::isRunning() const
 
 void HybrisAdaptor::stopAdaptor()
 {
-    qDebug() << Q_FUNC_INFO;
     if (getAdaptedSensor()->isRunning())
         stopSensor();
     hybrisManager()->closeSensors();
@@ -380,7 +382,6 @@ void HybrisAdaptor::stopAdaptor()
 
 bool HybrisAdaptor::startSensor()
 {
-    qDebug() << Q_FUNC_INFO;
     AdaptedSensorEntry *entry = getAdaptedSensor();
     if (entry == NULL) {
         qDebug() << "Sensor not found: " << name();

--- a/filters/avgaccfilter/avgaccfilter.cpp
+++ b/filters/avgaccfilter/avgaccfilter.cpp
@@ -20,32 +20,31 @@
 
 #include "avgaccfilter.h"
 #include <math.h>
+#define FILTER_COUNT 10
 
 AvgAccFilter::AvgAccFilter() :
     Filter<TimedXyzData, AvgAccFilter, TimedXyzData>(this, &AvgAccFilter::interpret),
     avgAccdata(0,0,0,0),
-    filterFactor(0.2)
+    filterFactor(0.54)
 {
 }
 
 void AvgAccFilter::interpret(unsigned, const TimedXyzData *data)
 {
-    avgAccdata.x_ = data->x_ * filterFactor + avgAccdata.x_ * (1.0 - filterFactor);
-    avgAccdata.y_ = data->y_ * filterFactor + avgAccdata.y_ * (1.0 - filterFactor);
-    avgAccdata.z_ = data->z_ * filterFactor + avgAccdata.z_ * (1.0 - filterFactor);
+    avgAccdata.x_ = data->x_ * filterFactor + averageX * (1.0f - filterFactor);
+    avgAccdata.y_ = data->y_ * filterFactor + averageY * (1.0f - filterFactor);
+    avgAccdata.z_ = data->z_ * filterFactor + averageZ * (1.0f - filterFactor);
 
     TimedXyzData filteredData(data->timestamp_,
                               avgAccdata.x_,
                               avgAccdata.y_,
                               avgAccdata.z_);
 
-    sensordLogT() << "averaged: "
-                  << filteredData.x_
-                  << ", "
-                  << filteredData.y_
-                  << ", " << filteredData.z_;
-
     source_.propagate(1, &filteredData);
+
+    averageX = data->x_;
+    averageY = data->y_;
+    averageZ = data->z_;
 }
 
 void AvgAccFilter::reset()
@@ -59,7 +58,6 @@ void AvgAccFilter::setFactor(qreal f)
 {
     filterFactor = f;
 }
-
 
 qreal AvgAccFilter::factor()
 {

--- a/filters/avgaccfilter/avgaccfilter.h
+++ b/filters/avgaccfilter/avgaccfilter.h
@@ -52,6 +52,13 @@ private:
     XyzAvgAccBuffer avgBuffer;
     unsigned int avgBufferSize;
     qreal filterFactor;
+
+    int averageX;
+    int averageY;
+    int averageZ;
+
+    QList<TimedXyzData> avgAccelBuffer;
+
 };
 
 #endif // ROTATIONFILTER_H

--- a/filters/declinationfilter/declinationfilter.cpp
+++ b/filters/declinationfilter/declinationfilter.cpp
@@ -44,25 +44,21 @@ DeclinationFilter::DeclinationFilter() :
 void DeclinationFilter::correct(unsigned, const CompassData* data)
 {
     CompassData newOrientation(*data);
-    if(newOrientation.timestamp_ - lastUpdate_ > updateInterval_)
-    {
+    if (newOrientation.timestamp_ - lastUpdate_ > updateInterval_) {
         loadSettings();
         lastUpdate_ = newOrientation.timestamp_;
     }
+
     newOrientation.correctedDegrees_ = newOrientation.degrees_;
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-    if(declinationCorrection_)
-#else
-    if(declinationCorrection_.loadAcquire() == 0)
-#endif
-    {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+    if (declinationCorrection_) {
         newOrientation.correctedDegrees_ += declinationCorrection_;
 #else
+    if (declinationCorrection_.loadAcquire() != 0) {
         newOrientation.correctedDegrees_ += declinationCorrection_.loadAcquire();
 #endif
         newOrientation.correctedDegrees_ %= 360;
-        sensordLogT() << "DeclinationFilter corrected degree " << newOrientation.degrees_ << " => " << newOrientation.correctedDegrees_ << ". Level: " << newOrientation.level_;
+//        sensordLogT() << "DeclinationFilter corrected degree " << newOrientation.degrees_ << " => " << newOrientation.correctedDegrees_ << ". Level: " << newOrientation.level_;
     }
     orientation_ = newOrientation;
     source_.propagate(1, &orientation_);

--- a/filters/downsamplefilter/downsamplefilter.cpp
+++ b/filters/downsamplefilter/downsamplefilter.cpp
@@ -25,6 +25,7 @@
 
 #include "downsamplefilter.h"
 #include "logging.h"
+// averaging filter
 
 DownsampleFilter::DownsampleFilter() :
     Filter<TimedXyzData, DownsampleFilter, TimedXyzData>(this, &DownsampleFilter::filter),
@@ -91,7 +92,7 @@ void DownsampleFilter::filter(unsigned, const TimedXyzData* data)
                              y / count,
                              z / count);
 
-    sensordLogT() << "Downsampled: " << downsampled.x_ << ", " << downsampled.y_ << ", " << downsampled.z_;
+//    sensordLogT() << "Downsampled: " << downsampled.x_ << ", " << downsampled.y_ << ", " << downsampled.z_;
 
     source_.propagate(1, &downsampled);
     buffer_.clear();

--- a/filters/filters.pro
+++ b/filters/filters.pro
@@ -4,7 +4,8 @@ SUBDIRS = coordinatealignfilter \
           orientationinterpreter \
           rotationfilter \
           downsamplefilter \
-          avgaccfilter
+          avgaccfilter \
+          magcoordinatealignfilter
 
 include(../common-install.pri)
 publicheaders.files = *.h

--- a/filters/magcoordinatealignfilter/magcoordinatealignfilter.cpp
+++ b/filters/magcoordinatealignfilter/magcoordinatealignfilter.cpp
@@ -1,0 +1,51 @@
+/**
+   @file magcoordinatealignfilter.cpp
+   @brief MagCoordinateAlignFilter
+
+   <p>
+   Copyright (C) 2009-2010 Nokia Corporation
+
+   @author Timo Rongas <ext-timo.2.rongas@nokia.com>
+   @author Antti Virtanen <antti.i.virtanen@nokia.com>
+
+   This file is part of Sensord.
+
+   Sensord is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License
+   version 2.1 as published by the Free Software Foundation.
+
+   Sensord is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Sensord.  If not, see <http://www.gnu.org/licenses/>.
+   </p>
+ */
+
+#include "magcoordinatealignfilter.h"
+
+MagCoordinateAlignFilter::MagCoordinateAlignFilter() :
+        Filter<CalibratedMagneticFieldData, MagCoordinateAlignFilter, CalibratedMagneticFieldData>(this, &MagCoordinateAlignFilter::filter)
+{
+}
+
+void MagCoordinateAlignFilter::filter(unsigned, const CalibratedMagneticFieldData* data)
+{
+    CalibratedMagneticFieldData transformed;
+
+    transformed.timestamp_ = data->timestamp_;
+
+    transformed.x_ = matrix_.get(0,0)*data->x_ + matrix_.get(0,1)*data->y_ + matrix_.get(0,2)*data->z_;
+    transformed.y_ = matrix_.get(1,0)*data->x_ + matrix_.get(1,1)*data->y_ + matrix_.get(1,2)*data->z_;
+    transformed.z_ = matrix_.get(2,0)*data->x_ + matrix_.get(2,1)*data->y_ + matrix_.get(2,2)*data->z_;
+
+    transformed.rx_ = matrix_.get(0,0)*data->rx_ + matrix_.get(0,1)*data->ry_ + matrix_.get(0,2)*data->rz_;
+    transformed.ry_ = matrix_.get(1,0)*data->rx_ + matrix_.get(1,1)*data->ry_ + matrix_.get(1,2)*data->rz_;
+    transformed.rz_ = matrix_.get(2,0)*data->rx_ + matrix_.get(2,1)*data->ry_ + matrix_.get(2,2)*data->rz_;
+
+    transformed.level_ = data->level_;
+
+    source_.propagate(1, &transformed);
+}

--- a/filters/magcoordinatealignfilter/magcoordinatealignfilter.h
+++ b/filters/magcoordinatealignfilter/magcoordinatealignfilter.h
@@ -1,0 +1,105 @@
+/**
+   @file magcoordinatealignfilter.h
+   @brief MagCoordinateAlignFilter
+
+   <p>
+   Copyright (C) 2009-2010 Nokia Corporation
+
+   @author Timo Rongas <ext-timo.2.rongas@nokia.com>
+   @author Antti Virtanen <antti.i.virtanen@nokia.com>
+
+   This file is part of Sensord.
+
+   Sensord is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License
+   version 2.1 as published by the Free Software Foundation.
+
+   Sensord is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Sensord.  If not, see <http://www.gnu.org/licenses/>.
+   </p>
+ */
+
+#ifndef MAGCOORDINATEALIGNFILTER_H
+#define MAGCOORDINATEALIGNFILTER_H
+
+#include "datatypes/orientationdata.h"
+#include "filter.h"
+
+/**
+ * TMagMatrix holds a transformation matrix.
+ */
+class TMagMatrix {
+private:
+    static const int DIM = 3;
+
+public:
+    TMagMatrix() {
+        setMatrix((const double[DIM][DIM]){{1,0,0},{0,1,0},{0,0,1}});
+    }
+    TMagMatrix(const TMagMatrix& other) {
+        setMatrix(other.data_);
+    }
+    TMagMatrix(double m[][DIM]) {
+        setMatrix(m);
+    }
+
+    double get(int i, int j) const {
+        if (i >= DIM || j >= DIM || i < 0 || j < 0) {
+            qWarning("Index out of bounds");
+            return 0;
+        }
+        return data_[i][j];
+    };
+
+    void setMatrix(const double m[DIM][DIM]) {
+        memcpy(data_, m, sizeof(double[DIM][DIM]));
+    }
+
+    double data_[DIM][DIM];
+};
+Q_DECLARE_METATYPE(TMagMatrix)
+
+/**
+ * @brief Coordinate alignment filter.
+ *
+ * Performs three dimensional coordinate transformations.
+ * Transformation is described by transformation matrix which is set through
+ * \c TMatrix property. Matrix must be of size 3x3. Default TMatrix is
+ * identity matrix.
+ */
+class MagCoordinateAlignFilter : public QObject, public Filter<CalibratedMagneticFieldData, MagCoordinateAlignFilter, CalibratedMagneticFieldData>
+{
+    Q_OBJECT
+    Q_PROPERTY(TMagMatrix transMatrix READ matrix WRITE setMatrix)
+public:
+
+    /**
+     * Factory method.
+     * @return New MagCoordinateAlignFilter instance as FilterBase*.
+     */
+    static FilterBase* factoryMethod() {
+        return new MagCoordinateAlignFilter;
+    }
+
+    const TMagMatrix& matrix() const { return matrix_; }
+
+    void setMatrix(const TMagMatrix& matrix) { matrix_ = matrix; }
+
+protected:
+    /**
+     * Constructor.
+     */
+    MagCoordinateAlignFilter();
+
+private:
+    void filter(unsigned, const CalibratedMagneticFieldData*);
+
+    TMagMatrix matrix_;
+};
+
+#endif // MagCoordinateAlignFilter_H

--- a/filters/magcoordinatealignfilter/magcoordinatealignfilter.pro
+++ b/filters/magcoordinatealignfilter/magcoordinatealignfilter.pro
@@ -1,0 +1,9 @@
+TARGET = magcoordinatealignfilter
+
+HEADERS += magcoordinatealignfilter.h \
+           magcoordinatealignfilterplugin.h
+
+SOURCES += magcoordinatealignfilter.cpp \
+           magcoordinatealignfilterplugin.cpp
+
+include( ../filter-config.pri )

--- a/filters/magcoordinatealignfilter/magcoordinatealignfilterplugin.cpp
+++ b/filters/magcoordinatealignfilter/magcoordinatealignfilterplugin.cpp
@@ -1,7 +1,11 @@
-/****************************************************************************
-**
-** Copyright (C) 2013 Jolla Ltd
-** Contact: lorn.potter@jollamobile.com
+/**
+   @file MagCoordinateAlignFilterPlugin.cpp
+   @brief Plugin for CoordinateAlignFilter
+
+   <p>
+   Copyright (C) 2009-2010 Nokia Corporation
+
+   @author Timo Rongas <ext-timo.2.rongas@nokia.com>
 
    This file is part of Sensord.
 
@@ -16,26 +20,21 @@
 
    You should have received a copy of the GNU Lesser General Public
    License along with Sensord.  If not, see <http://www.gnu.org/licenses/>.
+   </p>
  */
 
-#include "magcalibrationchainplugin.h"
-#include "magcalibrationchain.h"
-#include "calibrationfilter.h"
+#include "magcoordinatealignfilterplugin.h"
+#include "magcoordinatealignfilter.h"
 #include "sensormanager.h"
 #include "logging.h"
 
-void MagCalibrationChainPlugin::Register(class Loader&)
+void MagCoordinateAlignFilterPlugin::Register(class Loader&)
 {
-    sensordLogD() << "registering magcalibrationchain";
+    sensordLogD() << "registering magcoordinatealignfilter";
     SensorManager& sm = SensorManager::instance();
-    sm.registerFilter<CalibrationFilter>("calibrationfilter");
-    sm.registerChain<MagCalibrationChain>("magcalibrationchain");
-}
-
-QStringList MagCalibrationChainPlugin::Dependencies() {
-    return QString("magcoordinatealignfilter:magnetometeradaptor").split(":", QString::SkipEmptyParts);
+    sm.registerFilter<MagCoordinateAlignFilter>("magcoordinatealignfilter");
 }
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-Q_EXPORT_PLUGIN2(magcalibrationchain, MagCalibrationChainPlugin)
+Q_EXPORT_PLUGIN2(magcoordinatealignfilter, MagCoordinateAlignFilterPlugin)
 #endif

--- a/filters/magcoordinatealignfilter/magcoordinatealignfilterplugin.h
+++ b/filters/magcoordinatealignfilter/magcoordinatealignfilterplugin.h
@@ -1,6 +1,6 @@
 /**
-   @file magnetometerplugin.cpp
-   @brief Plugin for MagnetometerSensor
+   @file coordinatealignfilterplugin.h
+   @brief Plugin for CoordinateAlignFilter
 
    <p>
    Copyright (C) 2009-2010 Nokia Corporation
@@ -21,25 +21,21 @@
    You should have received a copy of the GNU Lesser General Public
    License along with Sensord.  If not, see <http://www.gnu.org/licenses/>.
    </p>
-*/
+ */
 
-#include "magnetometerplugin.h"
-#include "magnetometersensor.h"
-#include "magnetometerscalefilter.h"
-#include "sensormanager.h"
-#include "logging.h"
+#ifndef MAGCOORDINATEALIGNFILTERPLUGIN_H
+#define MAGCOORDINATEALIGNFILTERPLUGIN_H
 
-void MagnetometerPlugin::Register(class Loader&)
+#include "plugin.h"
+
+class MagCoordinateAlignFilterPlugin : public Plugin
 {
-    SensorManager& sm = SensorManager::instance();
-    sm.registerSensor<MagnetometerSensorChannel>("magnetometersensor");
-    sm.registerFilter<MagnetometerScaleFilter>("magnetometerscalefilter");
-}
+    Q_OBJECT
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+    Q_PLUGIN_METADATA(IID "com.nokia.SensorService.Plugin/1.0")
+#endif
+private:
+    void Register(class Loader& l);
+};
 
-QStringList MagnetometerPlugin::Dependencies() {
-    return QString("magcalibrationchain").split(":", QString::SkipEmptyParts);
-}
-
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-Q_EXPORT_PLUGIN2(magnetometersensor, MagnetometerPlugin)
 #endif

--- a/filters/orientationinterpreter/orientationinterpreter.cpp
+++ b/filters/orientationinterpreter/orientationinterpreter.cpp
@@ -221,7 +221,7 @@ void OrientationInterpreter::processFace()
     if (abs(data.z_) >= 300)
     {
         PoseData newFace;
-        newFace.orientation_ = ((data.z_ >= 0) ? PoseData::FaceDown : PoseData::FaceUp);
+        newFace.orientation_ = ((data.z_ <= 0) ? PoseData::FaceDown : PoseData::FaceUp);
 
         if (newFace.orientation_ == PoseData::FaceDown)
         {

--- a/sensors/magnetometersensor/magnetometerscalefilter.cpp
+++ b/sensors/magnetometersensor/magnetometerscalefilter.cpp
@@ -30,7 +30,7 @@
 MagnetometerScaleFilter::MagnetometerScaleFilter() :
         Filter<CalibratedMagneticFieldData, MagnetometerScaleFilter, CalibratedMagneticFieldData>(this, &MagnetometerScaleFilter::filter)
 {
-    factor = Config::configuration()->value("magnetometer/scale_coefficient", QVariant(300)).toInt();;
+    factor = Config::configuration()->value("magnetometer/scale_coefficient", QVariant(1)).toInt();
 }
 
 void MagnetometerScaleFilter::filter(unsigned, const CalibratedMagneticFieldData* data)

--- a/sensors/magnetometersensor/magnetometersensor.h
+++ b/sensors/magnetometersensor/magnetometersensor.h
@@ -94,7 +94,7 @@ protected:
 private:
     Bin*                                       filterBin_;
     Bin*                                       marshallingBin_;
-    AbstractChain*                             compassChain_;
+    AbstractChain*                             magChain_;
     FilterBase*                                scaleFilter_;
     BufferReader<CalibratedMagneticFieldData>* magnetometerReader_;
     RingBuffer<CalibratedMagneticFieldData>*   outputBuffer_;

--- a/sensors/orientationsensor/orientationsensor.cpp
+++ b/sensors/orientationsensor/orientationsensor.cpp
@@ -53,7 +53,6 @@ OrientationSensorChannel::OrientationSensorChannel(const QString& id) :
 
     // Join filterchain buffers
     filterBin_->join("orientation", "source", "buffer", "sink");
-    filterBin_->join("face", "source", "buffer", "sink");
 
     // Join datasources to the chain
     connectToSource(orientationChain_, "orientation", orientationReader_);


### PR DESCRIPTION
* change magcalibration chain expected data type to
CalibratedMagneticFieldData

* add MagCoordinateAlignFilter to remap mag data points when needed

* invalidate the hybris adaptor if no sensor is dynamically found.

* if orientationadaptor (calibrated compass) is valid use it, otherwise
use sensorfw for calibration and compass routines.

This helps for hybris based systems, when virtual sensors are not
present. It keeps the default hybris configuration file usable.