### PR TITLE
[sensorfw] Fixes MER#904 Make sure hybris adaptor is being

### DIFF
--- a/core/hybrisadaptor.cpp
+++ b/core/hybrisadaptor.cpp
@@ -467,8 +467,8 @@ bool HybrisAdaptor::standby()
 
     inStandbyMode_ = true;
     sensordLogD() << "Adaptor '" << id() << "' going to standby";
-    running_ = deviceStandbyOverride();
     hybrisManager()->standbyReader(this);
+    running_ = deviceStandbyOverride();
 
     return true;
 }


### PR DESCRIPTION
deactivated correctly if standbyOverride is false and screen off.