### PR TITLE
[sensorfw] Fixes JB#30219 Don't stop thread on display off

### DIFF
--- a/core/hybrisadaptor.cpp
+++ b/core/hybrisadaptor.cpp
@@ -212,7 +212,7 @@ void HybrisManager::stopReader(HybrisAdaptor *adaptor)
                 sensordLogW() <<Q_FUNC_INFO<< "failed for"<< strerror(-error);
             }
         }
-        if (list.at(i) != adaptor && list.at(i)->isRunning()) {
+        if (list.at(i) != adaptor && list.at(i)->shouldBeRunning_) {
             okToStop = false;
         }
     }


### PR DESCRIPTION
hybris adaptor gets deactivated (power off)
but thread can be suspended before it terminates, and then
returns after the device suspention when it should be
restarted.