### PR TITLE
[sensorfw] Fixes MER#1284 explicitly resume and standby, regardless o…

### DIFF
--- a/adaptors/accelerometeradaptor/accelerometeradaptor.cpp
+++ b/adaptors/accelerometeradaptor/accelerometeradaptor.cpp
@@ -134,3 +134,15 @@ unsigned int AccelerometerAdaptor::evaluateIntervalRequests(int& sessionId) cons
     sessionId = winningSessionId;
     return highestValue > 0 ? highestValue : defaultInterval();
 }
+
+bool AccelerometerAdaptor::resume()
+{
+    if (SysfsAdaptor::resume())
+        SysfsAdaptor::startSensor();
+}
+
+bool AccelerometerAdaptor::standby()
+{
+    if (SysfsAdaptor::standby())
+        SysfsAdaptor::stopSensor();
+}

--- a/adaptors/accelerometeradaptor/accelerometeradaptor.h
+++ b/adaptors/accelerometeradaptor/accelerometeradaptor.h
@@ -59,6 +59,9 @@ public:
     virtual bool startSensor();
 
     virtual void stopSensor();
+    virtual bool standby();
+    virtual bool resume();
+
 protected:
     /**
      * Constructor.

--- a/adaptors/proximityadaptor-evdev/proximityadaptor-evdev.cpp
+++ b/adaptors/proximityadaptor-evdev/proximityadaptor-evdev.cpp
@@ -46,6 +46,7 @@ ProximityAdaptorEvdev::ProximityAdaptorEvdev(const QString& id) :
 {
     proximityBuffer_ = new DeviceAdaptorRingBuffer<ProximityData>(1);
     setAdaptedSensor("proximity", "Proximity state", proximityBuffer_);
+    powerStatePath_ = Config::configuration()->value("proximity/powerstate_path").toByteArray();
 }
 
 ProximityAdaptorEvdev::~ProximityAdaptorEvdev()

--- a/adaptors/proximityadaptor-evdev/proximityadaptor-evdev.h
+++ b/adaptors/proximityadaptor-evdev/proximityadaptor-evdev.h
@@ -82,6 +82,7 @@ private:
     void interpretEvent(int src, struct input_event *ev);
     void commitOutput(struct input_event *ev);
     void interpretSync(int src, struct input_event *ev);
+    QByteArray powerStatePath_;
 };
 
 #endif

--- a/core/deviceadaptor.cpp
+++ b/core/deviceadaptor.cpp
@@ -120,12 +120,10 @@ RingBufferBase* DeviceAdaptor::findBuffer(const QString& name) const
 bool DeviceAdaptor::setStandbyOverride(bool override)
 {
     standbyOverride_ = override;
-    if (screenBlanked_) {
-        if (override) {
-            resume();
-        } else {
-            standby();
-        }
+    if (override) {
+        resume();
+    } else {
+        standby();
     }
     sensordLogD() << "standbyOverride changed: id = " << id() << ", value = " <<  standbyOverride_;
     return true;

--- a/core/sysfsadaptor.cpp
+++ b/core/sysfsadaptor.cpp
@@ -173,13 +173,12 @@ bool SysfsAdaptor::standby()
         sensordLogD() << "Adaptor '" << id() << "' not going to standby: overriden";
         return false;
     }
-    inStandbyMode_ = true;
-
     if (!isRunning()) {
         sensordLogD() << "Adaptor '" << id() << "' not going to standby: not running";
         return false;
     }
 
+    inStandbyMode_ = true;
     sensordLogD() << "Adaptor '" << id() << "' going to standby";
     stopReaderThread();
     closeAllFds();
@@ -199,7 +198,6 @@ bool SysfsAdaptor::resume()
         return false;
     }
 
-    inStandbyMode_ = false;
 
     if (!shouldBeRunning_) {
         sensordLogD() << "Adaptor '" << id() << "' not resuming from standby: not running";
@@ -207,6 +205,7 @@ bool SysfsAdaptor::resume()
     }
 
     sensordLogD() << "Adaptor '" << id() << "' resuming from standby";
+    inStandbyMode_ = false;
 
     if (!startReaderThread()) {
         sensordLogW() << "Adaptor '" << id() << "' failed to resume from standby!";


### PR DESCRIPTION
…f screen blank.

Sometimes the screen is either blanked too soon, or after this runs at resume, so just ignore if screen is blanked at this point.

Screen blanking actions are handled elsewhere.
