### PR TITLE
[sensorfw] FIXES JB#31877 Explicity turn off adaptors when blanking

### DIFF
--- a/adaptors/accelerometeradaptor/accelerometeradaptor.cpp
+++ b/adaptors/accelerometeradaptor/accelerometeradaptor.cpp
@@ -137,12 +137,12 @@ unsigned int AccelerometerAdaptor::evaluateIntervalRequests(int& sessionId) cons
 
 bool AccelerometerAdaptor::resume()
 {
-    if (SysfsAdaptor::resume())
-        SysfsAdaptor::startSensor();
+   startSensor();
+   return true;
 }
 
 bool AccelerometerAdaptor::standby()
 {
-    if (SysfsAdaptor::standby())
-        SysfsAdaptor::stopSensor();
+    stopSensor();
+    return true;
 }

--- a/adaptors/alsadaptor-evdev/alsevdevadaptor.cpp
+++ b/adaptors/alsadaptor-evdev/alsevdevadaptor.cpp
@@ -134,18 +134,12 @@ void ALSAdaptorEvdev::stopSensor()
 
 bool ALSAdaptorEvdev::standby()
 {
-    if (SysfsAdaptor::standby()) {
-        stopSensor();
-        return true;
-    }
-    return false;
+    stopSensor();
+    return true;
 }
 
 bool ALSAdaptorEvdev::resume()
 {
-    if (SysfsAdaptor::resume()) {
-        startSensor();
-        return true;
-    }
-    return false;
+    startSensor();
+    return true;
 }

--- a/adaptors/gyroscopeadaptor-evdev/gyroevdevadaptor.cpp
+++ b/adaptors/gyroscopeadaptor-evdev/gyroevdevadaptor.cpp
@@ -143,18 +143,12 @@ void GyroAdaptorEvdev::stopSensor()
 
 bool GyroAdaptorEvdev::standby()
 {
-    if (SysfsAdaptor::standby()) {
-        stopSensor();
-        return true;
-    }
-    return false;
+    stopSensor();
+    return true;
 }
 
 bool GyroAdaptorEvdev::resume()
 {
-    if (SysfsAdaptor::resume()) {
-        startSensor();
-        return true;
-    }
-    return false;
+    startSensor();
+    return true;
 }

--- a/adaptors/magnetometeradaptor-evdev/magnetometerevdevadaptor.cpp
+++ b/adaptors/magnetometeradaptor-evdev/magnetometerevdevadaptor.cpp
@@ -142,18 +142,12 @@ void MagAdaptorEvdev::stopSensor()
 
 bool MagAdaptorEvdev::standby()
 {
-    if (SysfsAdaptor::standby()) {
-        stopSensor();
-        return true;
-    }
-    return false;
+    stopSensor();
+    return true;
 }
 
 bool MagAdaptorEvdev::resume()
 {
-    if (SysfsAdaptor::resume()) {
-        startSensor();
-        return true;
-    }
-    return false;
+    startSensor();
+    return true;
 }

--- a/adaptors/proximityadaptor-evdev/proximityadaptor-evdev.cpp
+++ b/adaptors/proximityadaptor-evdev/proximityadaptor-evdev.cpp
@@ -116,18 +116,12 @@ void ProximityAdaptorEvdev::stopSensor()
 
 bool ProximityAdaptorEvdev::standby()
 {
-    if (SysfsAdaptor::standby()) {
-        stopSensor();
-        return true;
-    }
-    return false;
+    stopSensor();
+    return true;
 }
 
 bool ProximityAdaptorEvdev::resume()
 {
-    if (SysfsAdaptor::resume()) {
-        startSensor();
-        return true;
-    }
-    return false;
+    startSensor();
+    return true;
 }

--- a/core/sensormanager.cpp
+++ b/core/sensormanager.cpp
@@ -130,7 +130,6 @@ SensorManager::SensorManager()
     }
 
 #ifdef SENSORFW_MCE_WATCHER
-
     mceWatcher_ = new MceWatcher(this);
     connect(mceWatcher_, SIGNAL(displayStateChanged(const bool)),
             this, SLOT(displayStateChanged(const bool)));
@@ -687,7 +686,7 @@ void SensorManager::printStatus(QStringList& output) const
 {
     output.append("  Adaptors:");
     for (QMap<QString, DeviceAdaptorInstanceEntry>::const_iterator it = deviceAdaptorInstanceMap_.constBegin(); it != deviceAdaptorInstanceMap_.constEnd(); ++it) {
-        output.append(QString("    %1 [%2 listener(s)]").arg(it.value().type_).arg(it.value().cnt_));
+        output.append(QString("    %1 [%2 listener(s)] %3").arg(it.value().type_).arg(it.value().cnt_).arg(it.value().adaptor_->deviceStandbyOverride() ? "Standby Overriden" : "No standby override"));
     }
 
     output.append("  Chains:\n");

--- a/core/sysfsadaptor.cpp
+++ b/core/sysfsadaptor.cpp
@@ -146,10 +146,6 @@ void SysfsAdaptor::stopSensor()
         return;
     }
 
-    if (!shouldBeRunning_) {
-        return;
-    }
-
     entry->removeReference();
     if (entry->referenceCount() <= 0) {
         if (!inStandbyMode_) {
@@ -158,7 +154,6 @@ void SysfsAdaptor::stopSensor()
         }
         entry->setIsRunning(false);
         running_ = false;
-        shouldBeRunning_ = false;
     }
 }
 
@@ -179,12 +174,13 @@ bool SysfsAdaptor::standby()
     }
 
     inStandbyMode_ = true;
+    shouldBeRunning_ = true;
     sensordLogD() << "Adaptor '" << id() << "' going to standby";
     stopReaderThread();
     closeAllFds();
 
     running_ = false;
-
+    stopAdaptor();
     return true;
 }
 
@@ -213,6 +209,7 @@ bool SysfsAdaptor::resume()
     }
 
     running_ = true;
+    startAdaptor();
     return true;
 }
 


### PR DESCRIPTION
screen. Fix evdev adaptors to enable/disable sensors.

Add standby override status to USR2 output.
Tested this change on sbj, tbj (hybris plugins) and evdev plugins.