### PR TITLE
Fixes JB#32538 Ignore setDelay errors

### DIFF
--- a/core/hybrisadaptor.cpp
+++ b/core/hybrisadaptor.cpp
@@ -173,10 +173,13 @@ int HybrisManager::resolution(int sensorType)
 
 bool HybrisManager::setDelay(int sensorHandle, int interval)
 {
-    int result = device->setDelay(device, sensorHandle, interval);
-    if (result < 0) {
-        sensordLogW() << "setDelay() failed" << strerror(-result);
-        return false;
+    bool ok = true;
+    if (interval > 0) {
+        int result = device->setDelay(device, sensorHandle, interval);
+        if (result < 0) {
+            sensordLogW() << "setDelay() failed" << strerror(-result);
+            ok = false;
+        }
     }
     QList <HybrisAdaptor *> list;
     list = registeredAdaptors.values();
@@ -186,7 +189,7 @@ bool HybrisManager::setDelay(int sensorHandle, int interval)
         }
     }
 
-    return true;
+    return ok;
 }
 
 void HybrisManager::startReader(HybrisAdaptor *adaptor)


### PR DESCRIPTION
0 is a special interval meaning client does not care about poll speed.
We need to ignore this to send initial data from sensor adaptors.

We also ignore any errors from wrong interval value being tried.